### PR TITLE
Add dns-sync import command

### DIFF
--- a/src/DnsSync/Commands/ImportCommand.cs
+++ b/src/DnsSync/Commands/ImportCommand.cs
@@ -1,0 +1,116 @@
+using DnsSync.Providers;
+using DnsSync.Providers.Yaml;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace DnsSync.Commands;
+
+public class ImportCommand(ILoggerFactory loggerFactory) : AsyncCommand<ImportSettings>
+{
+    protected override async Task<int> ExecuteAsync(
+        CommandContext context, ImportSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = CommandHelpers.LoadAndValidateConfig(settings);
+
+            if (string.IsNullOrWhiteSpace(settings.Provider))
+            {
+                AnsiConsole.MarkupLine("[red]✗[/] --provider is required.");
+                return 1;
+            }
+
+            if (!config.Providers.TryGetValue(settings.Provider, out var providerConfig))
+            {
+                AnsiConsole.MarkupLine($"[red]✗[/] Provider '{Markup.Escape(settings.Provider)}' not found in config.");
+                return 1;
+            }
+
+            if (!settings.All && string.IsNullOrWhiteSpace(settings.Zone))
+            {
+                AnsiConsole.MarkupLine("[red]✗[/] Specify --zone <ZONE> or --all.");
+                return 1;
+            }
+
+            var provider = ProviderFactory.Create(settings.Provider, providerConfig, loggerFactory);
+
+            AnsiConsole.MarkupLine($"\nRunning pre-flight for [bold]{Markup.Escape(settings.Provider)}[/]...");
+            await provider.PreflightAsync(cancellationToken);
+            AnsiConsole.MarkupLine($"[green]✓[/] Provider reachable");
+
+            var outputDir = Path.GetFullPath(settings.Output);
+            Directory.CreateDirectory(outputDir);
+
+            IReadOnlyList<string> zones;
+            if (settings.All)
+            {
+                zones = await AnsiConsole.Status().StartAsync(
+                    "Fetching zone list...",
+                    async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        return await provider.GetZonesAsync(cancellationToken);
+                    });
+
+                AnsiConsole.MarkupLine($"[green]✓[/] Found [bold]{zones.Count}[/] zone(s)");
+            }
+            else
+            {
+                zones = [settings.Zone!];
+            }
+
+            var imported = 0;
+            var skipped = 0;
+
+            foreach (var zoneName in zones)
+            {
+                var outputPath = Path.Combine(outputDir, zoneName.TrimEnd('.') + ".yaml");
+
+                if (File.Exists(outputPath) && !settings.Force)
+                {
+                    AnsiConsole.MarkupLine(
+                        $"  [yellow]~[/] {Markup.Escape(zoneName)} — skipped (file exists, use --force to overwrite)");
+                    skipped++;
+                    continue;
+                }
+
+                var zone = await AnsiConsole.Status().StartAsync(
+                    $"Fetching {zoneName}...",
+                    async ctx =>
+                    {
+                        ctx.Spinner(Spinner.Known.Dots);
+                        return await provider.GetZoneAsync(zoneName, cancellationToken);
+                    });
+
+                var yaml = ZoneYamlSerializer.Serialize(zone);
+                await File.WriteAllTextAsync(outputPath, yaml, cancellationToken);
+
+                AnsiConsole.MarkupLine(
+                    $"  [green]+[/] {Markup.Escape(zoneName)} → [dim]{Markup.Escape(outputPath)}[/] " +
+                    $"([bold]{zone.Records.Count}[/] record(s))");
+                imported++;
+            }
+
+            AnsiConsole.WriteLine();
+
+            if (imported > 0)
+                AnsiConsole.MarkupLine(
+                    $"[green]✓[/] Imported [bold]{imported}[/] zone(s) to [bold]{Markup.Escape(outputDir)}[/]");
+
+            if (skipped > 0)
+                AnsiConsole.MarkupLine($"[yellow]~[/] Skipped [bold]{skipped}[/] zone(s) (already exist)");
+
+            if (imported > 0)
+                AnsiConsole.MarkupLine(
+                    $"\nRun [bold]dns-sync validate[/] to verify the imported zones.");
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            CommandHelpers.PrintError(ex, settings.Verbose);
+            return 1;
+        }
+    }
+}

--- a/src/DnsSync/Commands/ImportSettings.cs
+++ b/src/DnsSync/Commands/ImportSettings.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace DnsSync.Commands;
+
+public class ImportSettings : BaseSettings
+{
+    [CommandOption("--provider <NAME>")]
+    [Description("Provider name from config to import from")]
+    public string Provider { get; set; } = string.Empty;
+
+    [CommandOption("--zone <ZONE>")]
+    [Description("Import a single zone (e.g. example.com.)")]
+    public string? Zone { get; set; }
+
+    [CommandOption("--all")]
+    [Description("Import all zones from the provider")]
+    public bool All { get; set; }
+
+    [CommandOption("--output <DIR>")]
+    [Description("Directory to write zone YAML files (default: ./zones)")]
+    [DefaultValue("./zones")]
+    public string Output { get; set; } = "./zones";
+
+    [CommandOption("--force")]
+    [Description("Overwrite existing zone files")]
+    public bool Force { get; set; }
+}

--- a/src/DnsSync/Program.cs
+++ b/src/DnsSync/Program.cs
@@ -138,6 +138,10 @@ app.Configure(config =>
     config.AddCommand<ApplyCommand>("apply")
         .WithDescription("Apply changes from source to all target providers")
         .WithExample(["apply", "--config", "config.yaml", "--yes"]);
+
+    config.AddCommand<ImportCommand>("import")
+        .WithDescription("Import current DNS state from a provider into YAML zone files")
+        .WithExample(["import", "--config", "config.yaml", "--provider", "cloudflare", "--all"]);
 });
 
 return await app.RunAsync(args);

--- a/src/DnsSync/Providers/Yaml/ZoneYamlSerializer.cs
+++ b/src/DnsSync/Providers/Yaml/ZoneYamlSerializer.cs
@@ -1,0 +1,144 @@
+using System.Text;
+using DnsSync.Core;
+using DnsSync.Core.Records;
+
+namespace DnsSync.Providers.Yaml;
+
+/// <summary>
+/// Serializes a DnsZone to the YAML format consumed by YamlProvider.
+/// Output is human-readable and can be round-tripped through YamlProvider.ParseZoneYaml.
+/// </summary>
+public static class ZoneYamlSerializer
+{
+    public static string Serialize(DnsZone zone)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Zone: {zone.Name}");
+        sb.AppendLine($"# Imported by dns-sync on {DateTime.UtcNow:yyyy-MM-dd}");
+        sb.AppendLine();
+
+        // Group records by subdomain key for output
+        var bySubdomain = zone.Records
+            .GroupBy(r => SubdomainKey(r.Name, zone.Name))
+            .OrderBy(g => g.Key == "" ? "\0" : g.Key); // apex first
+
+        foreach (var group in bySubdomain)
+        {
+            var key = group.Key;
+            var records = group.ToList();
+            var yamlKey = key == "" ? "''" : key;
+
+            if (records.Count == 1)
+            {
+                sb.AppendLine($"{yamlKey}:");
+                AppendRecord(sb, records[0], indent: "  ");
+            }
+            else
+            {
+                sb.AppendLine($"{yamlKey}:");
+                foreach (var record in records)
+                {
+                    sb.AppendLine("  -");
+                    AppendRecord(sb, record, indent: "    ");
+                }
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd() + "\n";
+    }
+
+    private static void AppendRecord(StringBuilder sb, DnsRecord record, string indent)
+    {
+        sb.AppendLine($"{indent}type: {record.Type}");
+        sb.AppendLine($"{indent}ttl: {record.Ttl}");
+
+        switch (record)
+        {
+            case ARecord a:
+                AppendStringList(sb, a.Addresses, indent);
+                break;
+
+            case AaaaRecord aaaa:
+                AppendStringList(sb, aaaa.Addresses, indent);
+                break;
+
+            case CnameRecord cname:
+                sb.AppendLine($"{indent}value: {cname.Target}");
+                break;
+
+            case MxRecord mx:
+                sb.AppendLine($"{indent}values:");
+                foreach (var v in mx.Values)
+                    sb.AppendLine($"{indent}  - {{preference: {v.Preference}, exchange: {v.Exchange}}}");
+                break;
+
+            case TxtRecord txt:
+                if (txt.Values.Count == 1)
+                    sb.AppendLine($"{indent}value: {QuoteTxt(txt.Values[0])}");
+                else
+                    AppendQuotedStringList(sb, txt.Values, indent);
+                break;
+
+            case NsRecord ns:
+                AppendStringList(sb, ns.Nameservers, indent);
+                break;
+
+            case CaaRecord caa:
+                sb.AppendLine($"{indent}values:");
+                foreach (var v in caa.Values)
+                    sb.AppendLine($"{indent}  - {{flags: {v.Flags}, tag: {v.Tag}, value: \"{v.Value}\"}}");
+                break;
+
+            case SrvRecord srv:
+                sb.AppendLine($"{indent}values:");
+                foreach (var v in srv.Values)
+                    sb.AppendLine(
+                        $"{indent}  - {{priority: {v.Priority}, weight: {v.Weight}, port: {v.Port}, target: {v.Target}}}");
+                break;
+        }
+    }
+
+    private static void AppendStringList(StringBuilder sb, IReadOnlyList<string> values, string indent)
+    {
+        if (values.Count == 1)
+        {
+            sb.AppendLine($"{indent}value: {values[0]}");
+            return;
+        }
+
+        sb.AppendLine($"{indent}values:");
+        foreach (var v in values)
+            sb.AppendLine($"{indent}  - {v}");
+    }
+
+    private static void AppendQuotedStringList(StringBuilder sb, IReadOnlyList<string> values, string indent)
+    {
+        sb.AppendLine($"{indent}values:");
+        foreach (var v in values)
+            sb.AppendLine($"{indent}  - {QuoteTxt(v)}");
+    }
+
+    private static string QuoteTxt(string value)
+    {
+        // Wrap in double quotes if contains spaces or special chars, escaping inner quotes
+        if (value.Contains(' ') || value.Contains('"') || value.Contains('\\') || value.Contains(':'))
+            return $"\"{value.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"";
+        return value;
+    }
+
+    private static string SubdomainKey(string fqdn, string zoneName)
+    {
+        var zone = zoneName.TrimEnd('.');
+        var name = fqdn.TrimEnd('.');
+
+        if (string.Equals(name, zone, StringComparison.OrdinalIgnoreCase))
+            return "";
+
+        if (name.EndsWith("." + zone, StringComparison.OrdinalIgnoreCase))
+            return name[..^(zone.Length + 1)];
+
+        return name;
+    }
+}

--- a/tests/DnsSync.Tests/Providers/Yaml/ZoneYamlSerializerTests.cs
+++ b/tests/DnsSync.Tests/Providers/Yaml/ZoneYamlSerializerTests.cs
@@ -1,0 +1,228 @@
+using DnsSync.Core;
+using DnsSync.Core.Records;
+using DnsSync.Providers.Yaml;
+using Shouldly;
+
+namespace DnsSync.Tests.Providers.Yaml;
+
+public class ZoneYamlSerializerTests
+{
+    private static DnsZone MakeZone(params DnsRecord[] records) => new()
+    {
+        Name = "example.com.",
+        Records = records
+    };
+
+    [Fact]
+    public void Serialize_ARecord_RoundTrips()
+    {
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = ["1.2.3.4", "5.6.7.8"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+
+        var record = parsed.OfType<ARecord>().Single();
+        record.Name.ShouldBe("www.example.com.");
+        record.Ttl.ShouldBe(300);
+        record.Addresses.ShouldBe(["1.2.3.4", "5.6.7.8"]);
+    }
+
+    [Fact]
+    public void Serialize_ApexRecord_UsesEmptyKey()
+    {
+        var zone = MakeZone(new ARecord
+        {
+            Name = "example.com.",
+            Type = "A",
+            Ttl = 3600,
+            Addresses = ["1.2.3.4"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        yaml.ShouldContain("'':");
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        parsed.OfType<ARecord>().Single().Name.ShouldBe("example.com.");
+    }
+
+    [Fact]
+    public void Serialize_CnameRecord_RoundTrips()
+    {
+        var zone = MakeZone(new CnameRecord
+        {
+            Name = "blog.example.com.",
+            Type = "CNAME",
+            Ttl = 600,
+            Target = "example.com."
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+
+        var record = parsed.OfType<CnameRecord>().Single();
+        record.Target.ShouldBe("example.com.");
+    }
+
+    [Fact]
+    public void Serialize_MxRecord_RoundTrips()
+    {
+        var zone = MakeZone(new MxRecord
+        {
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 3600,
+            Values =
+            [
+                new MxValue(10, "mail.example.com."),
+                new MxValue(20, "mail2.example.com.")
+            ]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+
+        var record = parsed.OfType<MxRecord>().Single();
+        record.Values.Count.ShouldBe(2);
+        record.Values[0].Preference.ShouldBe(10);
+        record.Values[0].Exchange.ShouldBe("mail.example.com.");
+        record.Values[1].Preference.ShouldBe(20);
+    }
+
+    [Fact]
+    public void Serialize_TxtRecord_QuotesValuesWithSpaces()
+    {
+        var zone = MakeZone(new TxtRecord
+        {
+            Name = "example.com.",
+            Type = "TXT",
+            Ttl = 600,
+            Values = ["v=spf1 include:_spf.google.com ~all"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        yaml.ShouldContain("\"v=spf1");
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        parsed.OfType<TxtRecord>().Single().Values[0].ShouldBe("v=spf1 include:_spf.google.com ~all");
+    }
+
+    [Fact]
+    public void Serialize_TxtRecord_MultiplValues_RoundTrips()
+    {
+        var zone = MakeZone(new TxtRecord
+        {
+            Name = "example.com.",
+            Type = "TXT",
+            Ttl = 600,
+            Values = ["v=spf1 ~all", "google-site-verification=abc123"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+
+        var record = parsed.OfType<TxtRecord>().Single();
+        record.Values.Count.ShouldBe(2);
+        record.Values.ShouldContain("v=spf1 ~all");
+        record.Values.ShouldContain("google-site-verification=abc123");
+    }
+
+    [Fact]
+    public void Serialize_NsRecord_RoundTrips()
+    {
+        var zone = MakeZone(new NsRecord
+        {
+            Name = "example.com.",
+            Type = "NS",
+            Ttl = 3600,
+            Nameservers = ["ns1.porkbun.com.", "ns2.porkbun.com."]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+
+        var record = parsed.OfType<NsRecord>().Single();
+        record.Nameservers.ShouldContain("ns1.porkbun.com.");
+        record.Nameservers.ShouldContain("ns2.porkbun.com.");
+    }
+
+    [Fact]
+    public void Serialize_CaaRecord_RoundTrips()
+    {
+        var zone = MakeZone(new CaaRecord
+        {
+            Name = "example.com.",
+            Type = "CAA",
+            Ttl = 3600,
+            Values = [new CaaValue(0, "issue", "letsencrypt.org")]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+
+        var record = parsed.OfType<CaaRecord>().Single();
+        record.Values[0].Flags.ShouldBe(0);
+        record.Values[0].Tag.ShouldBe("issue");
+        record.Values[0].Value.ShouldBe("letsencrypt.org");
+    }
+
+    [Fact]
+    public void Serialize_SrvRecord_RoundTrips()
+    {
+        var zone = MakeZone(new SrvRecord
+        {
+            Name = "_sip._tcp.example.com.",
+            Type = "SRV",
+            Ttl = 600,
+            Values = [new SrvValue(10, 20, 5060, "sip.example.com.")]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+
+        var record = parsed.OfType<SrvRecord>().Single();
+        record.Values[0].Priority.ShouldBe(10);
+        record.Values[0].Weight.ShouldBe(20);
+        record.Values[0].Port.ShouldBe(5060);
+        record.Values[0].Target.ShouldBe("sip.example.com.");
+    }
+
+    [Fact]
+    public void Serialize_MultipleRecordsSameSubdomain_WritesAsList()
+    {
+        var zone = MakeZone(
+            new ARecord { Name = "example.com.", Type = "A", Ttl = 3600, Addresses = ["1.2.3.4"] },
+            new MxRecord
+            {
+                Name = "example.com.",
+                Type = "MX",
+                Ttl = 3600,
+                Values = [new MxValue(10, "mail.example.com.")]
+            });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        parsed.OfType<ARecord>().ShouldHaveSingleItem();
+        parsed.OfType<MxRecord>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Serialize_ApexAppearsFirst()
+    {
+        var zone = MakeZone(
+            new CnameRecord { Name = "www.example.com.", Type = "CNAME", Ttl = 300, Target = "example.com." },
+            new ARecord { Name = "example.com.", Type = "A", Ttl = 3600, Addresses = ["1.2.3.4"] });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+
+        var apexPos = yaml.IndexOf("'':", StringComparison.Ordinal);
+        var wwwPos = yaml.IndexOf("www:", StringComparison.Ordinal);
+        apexPos.ShouldBeLessThan(wwwPos);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `dns-sync import` command that reads the current DNS state from any configured provider and writes it as YAML zone files compatible with the `yaml` provider
- New `ZoneYamlSerializer` handles all 8 supported record types with full round-trip fidelity
- 11 round-trip tests verify serialize → parse produces identical records

## Usage

```bash
# Import a single zone
dns-sync import -c config.yaml --provider porkbun --zone example.com.

# Import all zones from a provider
dns-sync import -c config.yaml --provider cloudflare --all

# Import to a custom directory, overwriting existing files
dns-sync import -c config.yaml --provider cloudflare --all --output ./zones --force
```

## Test plan

- [x] All 131 tests pass
- [x] `dotnet format --verify-no-changes` passes
- [x] Manual: import from Porkbun, run `dns-sync validate` on result
- [x] Manual: `--force` overwrites existing file, without it skips

Closes #21