### PR TITLE
feat: saved plan files with HMAC-SHA256 signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ config.yaml
 ## Zone files (local data, not for public repos)
 domains/
 
+## Local test fixtures
+local-test/
+
 ## OS
 .DS_Store
 Thumbs.db

--- a/src/DnsSync/Commands/ApplyCommand.cs
+++ b/src/DnsSync/Commands/ApplyCommand.cs
@@ -1,4 +1,5 @@
 using DnsSync.Core;
+using DnsSync.Plan;
 using DnsSync.Providers;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -19,6 +20,10 @@ public class ApplyCommand(ILoggerFactory loggerFactory) : AsyncCommand<ApplySett
             }
 
             var config = CommandHelpers.LoadAndValidateConfig(settings);
+
+            if (settings.FromPlan is not null)
+                return await ApplyFromPlanAsync(settings, config, cancellationToken);
+
 
             var useSpinners = !settings.GcpLogs && !settings.Verbose;
 
@@ -169,5 +174,110 @@ public class ApplyCommand(ILoggerFactory loggerFactory) : AsyncCommand<ApplySett
             CommandHelpers.PrintError(ex, settings.Verbose);
             return 1;
         }
+    }
+
+    private async Task<int> ApplyFromPlanAsync(
+        ApplySettings settings,
+        Config.DnsSyncConfig config,
+        CancellationToken cancellationToken)
+    {
+        AnsiConsole.MarkupLine($"\nLoading plan from [bold]{Markup.Escape(settings.FromPlan!)}[/]...");
+
+        SavedPlanBody savedPlan;
+        try
+        {
+            savedPlan = PlanFileSerializer.Load(settings.ConfigPath, settings.FromPlan!);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]✗ {Markup.Escape(ex.Message)}[/]");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine("[green]✓[/] Plan signature verified.");
+
+        var plans = new List<(string ZoneName, string TargetName, DnsPlan Plan, IProvider Provider)>();
+
+        foreach (var savedZone in savedPlan.Zones)
+        {
+            if (!config.Providers.TryGetValue(savedZone.Target, out var providerConfig))
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]✗ Plan references unknown provider '{Markup.Escape(savedZone.Target)}'.[/]");
+                return 1;
+            }
+
+            var provider = ProviderFactory.Create(savedZone.Target, providerConfig, loggerFactory);
+            var plan = PlanFileSerializer.ToDnsPlan(savedZone);
+            plans.Add((savedZone.Zone, savedZone.Target, plan, provider));
+        }
+
+        var totalChanges = plans.Sum(p => p.Plan.Total);
+
+        if (totalChanges == 0)
+        {
+            AnsiConsole.MarkupLine("\n[green]✓ Plan has no changes. Nothing to apply.[/]");
+            return 0;
+        }
+
+        foreach (var (zoneName, targetName, plan, _) in plans)
+            CommandHelpers.PrintPlan(plan, zoneName, targetName, settings.Wide);
+
+        if (!settings.Force && totalChanges > settings.MaxChanges)
+        {
+            AnsiConsole.MarkupLine(
+                $"\n[red]✗ Plan has {totalChanges} changes, which exceeds --max-changes {settings.MaxChanges}.[/]");
+            AnsiConsole.MarkupLine(
+                "  Pass [bold]--force[/] to override this safety limit, or increase [bold]--max-changes[/].");
+            return 1;
+        }
+
+        if (!settings.Yes)
+        {
+            AnsiConsole.WriteLine();
+            var confirmed = AnsiConsole.Confirm(
+                $"Apply [bold]{totalChanges}[/] change(s) from saved plan?", defaultValue: false);
+
+            if (!confirmed)
+            {
+                AnsiConsole.MarkupLine("[yellow]Aborted.[/]");
+                return 0;
+            }
+        }
+
+        AnsiConsole.WriteLine();
+        var useSpinners = !settings.GcpLogs && !settings.Verbose;
+        var exitCode = 0;
+
+        foreach (var (zoneName, targetName, plan, provider) in plans)
+        {
+            if (plan.IsEmpty) continue;
+
+            try
+            {
+                AnsiConsole.Markup($"Applying to [bold]{Markup.Escape(targetName)}[/]... ");
+                var result = useSpinners
+                    ? await AnsiConsole.Status().StartAsync($"Applying to {targetName}...",
+                        async ctx => { ctx.Spinner(Spinner.Known.Dots); return await provider.ApplyPlanAsync(zoneName, plan, cancellationToken); })
+                    : await provider.ApplyPlanAsync(zoneName, plan, cancellationToken);
+
+                if (result.IsSuccess)
+                    AnsiConsole.MarkupLine($"[green]✓ Applied {result.Applied} change(s)[/]");
+                else
+                {
+                    AnsiConsole.MarkupLine($"[yellow]⚠ Applied {result.Applied}, failed {result.Failed}[/]");
+                    foreach (var error in result.Errors)
+                        AnsiConsole.MarkupLine($"    [red]•[/] {Markup.Escape(error)}");
+                    exitCode = 1;
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]✗ {Markup.Escape(ex.Message)}[/]");
+                exitCode = 1;
+            }
+        }
+
+        return exitCode;
     }
 }

--- a/src/DnsSync/Commands/ApplySettings.cs
+++ b/src/DnsSync/Commands/ApplySettings.cs
@@ -17,4 +17,8 @@ public class ApplySettings : PlanSettings
     [CommandOption("--force")]
     [Description("Override --max-changes safety limit")]
     public bool Force { get; set; }
+
+    [CommandOption("--from-plan <PATH>")]
+    [Description("Apply a previously saved plan file instead of re-reading providers (skips GetZone)")]
+    public string? FromPlan { get; set; }
 }

--- a/src/DnsSync/Commands/PlanCommand.cs
+++ b/src/DnsSync/Commands/PlanCommand.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using DnsSync.Core;
+using DnsSync.Plan;
 using DnsSync.Providers;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -26,6 +27,9 @@ public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettin
 
             // JSON output accumulator
             var jsonZones = new List<object>();
+
+            // Accumulator for --save-plan
+            var savedZonePlans = new List<(string ZoneName, string TargetName, DnsPlan Plan)>();
 
             foreach (var (zoneName, zoneConfig) in config.Zones)
             {
@@ -102,6 +106,7 @@ public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettin
                             CommandHelpers.PrintPlan(plan, zoneName, targetName, settings.Wide);
                         }
 
+                        savedZonePlans.Add((zoneName, targetName, plan));
                         totalChanges += plan.Total;
                     }
                     catch (Exception ex)
@@ -117,14 +122,22 @@ public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettin
             if (jsonMode)
             {
                 Console.WriteLine(JsonSerializer.Serialize(jsonZones, new JsonSerializerOptions { WriteIndented = true }));
-                return hasErrors ? 1 : (settings.ExitCode && totalChanges > 0 ? 2 : 0);
+            }
+            else
+            {
+                if (totalChanges > 0)
+                    AnsiConsole.MarkupLine(
+                        $"\n[bold]{totalChanges} total change(s)[/] — run [bold]dns-sync apply[/] to apply.");
+                else if (!hasErrors)
+                    AnsiConsole.MarkupLine("\n[green]✓ All zones are in sync. No changes needed.[/]");
             }
 
-            if (totalChanges > 0)
-                AnsiConsole.MarkupLine(
-                    $"\n[bold]{totalChanges} total change(s)[/] — run [bold]dns-sync apply[/] to apply.");
-            else if (!hasErrors)
-                AnsiConsole.MarkupLine("\n[green]✓ All zones are in sync. No changes needed.[/]");
+            if (!hasErrors && settings.SavePlan is not null)
+            {
+                PlanFileSerializer.Save(settings.ConfigPath, savedZonePlans, settings.SavePlan);
+                if (!jsonMode)
+                    AnsiConsole.MarkupLine($"[green]✓[/] Plan saved to [bold]{Markup.Escape(settings.SavePlan)}[/]");
+            }
 
             return hasErrors ? 1 : (settings.ExitCode && totalChanges > 0 ? 2 : 0);
         }

--- a/src/DnsSync/Commands/PlanSettings.cs
+++ b/src/DnsSync/Commands/PlanSettings.cs
@@ -21,4 +21,8 @@ public class PlanSettings : BaseSettings
     [Description("Output format: text (default) or json")]
     [DefaultValue("text")]
     public string Output { get; set; } = "text";
+
+    [CommandOption("--save-plan <PATH>")]
+    [Description("Save the computed plan to a signed YAML file for later use with 'apply --from-plan'")]
+    public string? SavePlan { get; set; }
 }

--- a/src/DnsSync/Plan/PlanFileSerializer.cs
+++ b/src/DnsSync/Plan/PlanFileSerializer.cs
@@ -69,8 +69,7 @@ public static class PlanFileSerializer
 
         if (!string.Equals(file.Plan.ConfigHash, expectedConfigHash, StringComparison.Ordinal))
             throw new InvalidOperationException(
-                $"Config file has changed since this plan was generated. " +
-                $"Expected config hash {file.Plan.ConfigHash}, got {expectedConfigHash}. " +
+                "Config file has changed since this plan was generated. " +
                 "Re-run 'dns-sync plan --save-plan' to generate a fresh plan.");
 
         var bodyYaml = YamlSerializer.Serialize(file.Plan);

--- a/src/DnsSync/Plan/PlanFileSerializer.cs
+++ b/src/DnsSync/Plan/PlanFileSerializer.cs
@@ -1,0 +1,192 @@
+using System.Security.Cryptography;
+using System.Text;
+using DnsSync.Core;
+using DnsSync.Core.Records;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace DnsSync.Plan;
+
+public static class PlanFileSerializer
+{
+    private static readonly ISerializer YamlSerializer = new SerializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+        .Build();
+
+    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Builds a SavedPlanBody from the computed zone plans, signs it with HMAC-SHA256
+    /// (key = SHA256 of config file bytes), and writes the signed plan to <paramref name="outputPath"/>.
+    /// </summary>
+    public static void Save(
+        string configPath,
+        IEnumerable<(string ZoneName, string TargetName, DnsPlan Plan)> zonePlans,
+        string outputPath)
+    {
+        var configBytes = File.ReadAllBytes(configPath);
+        var configHashBytes = SHA256.HashData(configBytes);
+        var configHashHex = $"sha256:{Convert.ToHexString(configHashBytes).ToLowerInvariant()}";
+
+        var body = new SavedPlanBody
+        {
+            Version = 1,
+            CreatedAt = DateTime.UtcNow,
+            ConfigHash = configHashHex,
+            Zones = zonePlans
+                .Select(z => ToSavedZonePlan(z.ZoneName, z.TargetName, z.Plan))
+                .ToList()
+        };
+
+        var bodyYaml = YamlSerializer.Serialize(body);
+        var signature = ComputeSignature(configHashBytes, bodyYaml);
+
+        var file = new SavedPlanFile { Plan = body, Signature = signature };
+        File.WriteAllText(outputPath, YamlSerializer.Serialize(file), Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// Loads a saved plan file, verifies its signature against the current config file,
+    /// and returns the plan body. Throws <see cref="InvalidOperationException"/> if the
+    /// config has changed or the signature does not match.
+    /// </summary>
+    public static SavedPlanBody Load(string configPath, string planPath)
+    {
+        if (!File.Exists(planPath))
+            throw new FileNotFoundException($"Plan file not found: {planPath}");
+
+        var fileYaml = File.ReadAllText(planPath);
+        var file = YamlDeserializer.Deserialize<SavedPlanFile>(fileYaml)
+            ?? throw new InvalidOperationException("Plan file is empty or invalid.");
+
+        var configBytes = File.ReadAllBytes(configPath);
+        var configHashBytes = SHA256.HashData(configBytes);
+        var expectedConfigHash = $"sha256:{Convert.ToHexString(configHashBytes).ToLowerInvariant()}";
+
+        if (!string.Equals(file.Plan.ConfigHash, expectedConfigHash, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Config file has changed since this plan was generated. " +
+                $"Expected config hash {file.Plan.ConfigHash}, got {expectedConfigHash}. " +
+                "Re-run 'dns-sync plan --save-plan' to generate a fresh plan.");
+
+        var bodyYaml = YamlSerializer.Serialize(file.Plan);
+        var expectedSignature = ComputeSignature(configHashBytes, bodyYaml);
+
+        if (!CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(file.Signature),
+                Encoding.UTF8.GetBytes(expectedSignature)))
+            throw new InvalidOperationException(
+                "Plan file signature verification failed — the file may have been tampered with.");
+
+        return file.Plan;
+    }
+
+    /// <summary>Reconstructs a <see cref="DnsPlan"/> from a <see cref="SavedZonePlan"/>.</summary>
+    public static DnsPlan ToDnsPlan(SavedZonePlan savedZone)
+    {
+        var changes = savedZone.Changes.Select(c => new RecordChange
+        {
+            ChangeType = c.Type.ToLowerInvariant() switch
+            {
+                "create" => ChangeType.Create,
+                "update" => ChangeType.Update,
+                "delete" => ChangeType.Delete,
+                _ => throw new InvalidOperationException($"Unknown change type '{c.Type}' in plan file.")
+            },
+            Before = c.Before is null ? null : ToRecord(c.Name, c.RecordType, c.Before),
+            After  = c.After  is null ? null : ToRecord(c.Name, c.RecordType, c.After),
+        }).ToList();
+
+        return new DnsPlan { Changes = changes };
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private static string ComputeSignature(byte[] keyBytes, string bodyYaml)
+    {
+        var bodyBytes = Encoding.UTF8.GetBytes(bodyYaml);
+        var sigBytes = HMACSHA256.HashData(keyBytes, bodyBytes);
+        return $"sha256:{Convert.ToHexString(sigBytes).ToLowerInvariant()}";
+    }
+
+    private static SavedZonePlan ToSavedZonePlan(string zoneName, string targetName, DnsPlan plan) =>
+        new()
+        {
+            Zone = zoneName,
+            Target = targetName,
+            Changes = plan.Changes.Select(ToSavedChange).ToList()
+        };
+
+    private static SavedChange ToSavedChange(RecordChange c) =>
+        new()
+        {
+            Type = c.ChangeType.ToString().ToLowerInvariant(),
+            Name = c.RecordName,
+            RecordType = c.RecordType,
+            Before = c.Before is null ? null : ToSavedRecord(c.Before),
+            After  = c.After  is null ? null : ToSavedRecord(c.After),
+        };
+
+    private static SavedRecord ToSavedRecord(DnsRecord record) =>
+        new()
+        {
+            Ttl = record.Ttl,
+            Values = EncodeValues(record)
+        };
+
+    private static List<string> EncodeValues(DnsRecord record) => record switch
+    {
+        ARecord r     => [..r.Addresses],
+        AaaaRecord r  => [..r.Addresses],
+        CnameRecord r => [r.Target],
+        NsRecord r    => [..r.Nameservers],
+        TxtRecord r   => [..r.Values],
+        MxRecord r    => r.Values.OrderBy(v => v.Preference)
+                            .Select(v => $"{v.Preference} {v.Exchange}").ToList(),
+        SrvRecord r   => r.Values.OrderBy(v => v.Priority)
+                            .Select(v => $"{v.Priority} {v.Weight} {v.Port} {v.Target}").ToList(),
+        CaaRecord r   => r.Values.OrderBy(v => v.Tag)
+                            .Select(v => $"{v.Flags} {v.Tag} {v.Value}").ToList(),
+        _ => throw new InvalidOperationException($"Unsupported record type: {record.GetType().Name}")
+    };
+
+    private static DnsRecord ToRecord(string name, string type, SavedRecord saved) =>
+        type.ToUpperInvariant() switch
+        {
+            "A"    => new ARecord    { Name = name, Type = type, Ttl = saved.Ttl, Addresses   = saved.Values },
+            "AAAA" => new AaaaRecord { Name = name, Type = type, Ttl = saved.Ttl, Addresses   = saved.Values },
+            "NS"   => new NsRecord   { Name = name, Type = type, Ttl = saved.Ttl, Nameservers = saved.Values },
+            "TXT"  => new TxtRecord  { Name = name, Type = type, Ttl = saved.Ttl, Values      = saved.Values },
+            "CNAME" => new CnameRecord { Name = name, Type = type, Ttl = saved.Ttl,
+                           Target = saved.Values.FirstOrDefault() ?? string.Empty },
+            "MX" => new MxRecord { Name = name, Type = type, Ttl = saved.Ttl,
+                        Values = saved.Values.Select(ParseMx).ToList() },
+            "SRV" => new SrvRecord { Name = name, Type = type, Ttl = saved.Ttl,
+                         Values = saved.Values.Select(ParseSrv).ToList() },
+            "CAA" => new CaaRecord { Name = name, Type = type, Ttl = saved.Ttl,
+                         Values = saved.Values.Select(ParseCaa).ToList() },
+            _ => throw new InvalidOperationException($"Unsupported record type in plan file: {type}")
+        };
+
+    private static MxValue ParseMx(string s)
+    {
+        var parts = s.Split(' ', 2);
+        return new MxValue(int.Parse(parts[0]), parts[1]);
+    }
+
+    private static SrvValue ParseSrv(string s)
+    {
+        var parts = s.Split(' ', 4);
+        return new SrvValue(int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]), parts[3]);
+    }
+
+    private static CaaValue ParseCaa(string s)
+    {
+        var parts = s.Split(' ', 3);
+        return new CaaValue(int.Parse(parts[0]), parts[1], parts[2]);
+    }
+}

--- a/src/DnsSync/Plan/SavedPlan.cs
+++ b/src/DnsSync/Plan/SavedPlan.cs
@@ -1,0 +1,46 @@
+namespace DnsSync.Plan;
+
+public class SavedPlanFile
+{
+    public SavedPlanBody Plan { get; set; } = new();
+    public string Signature { get; set; } = string.Empty;  // "sha256:<hex>"
+}
+
+public class SavedPlanBody
+{
+    public int Version { get; set; } = 1;
+    public DateTime CreatedAt { get; set; }
+    public string ConfigHash { get; set; } = string.Empty;  // "sha256:<hex>"
+    public List<SavedZonePlan> Zones { get; set; } = [];
+}
+
+public class SavedZonePlan
+{
+    public string Zone { get; set; } = string.Empty;
+    public string Target { get; set; } = string.Empty;
+    public List<SavedChange> Changes { get; set; } = [];
+}
+
+public class SavedChange
+{
+    public string Type { get; set; } = string.Empty;       // "create", "update", "delete"
+    public string Name { get; set; } = string.Empty;
+    public string RecordType { get; set; } = string.Empty;
+    public SavedRecord? Before { get; set; }
+    public SavedRecord? After { get; set; }
+}
+
+/// <summary>
+/// Record snapshot in a saved plan. Values are encoded as strings, with type-specific conventions:
+/// A/AAAA/NS: one address per entry.
+/// CNAME: single target FQDN.
+/// TXT: one TXT string per entry (unquoted).
+/// MX: "priority exchange" (e.g. "10 mail.example.com.").
+/// SRV: "priority weight port target" (e.g. "10 20 443 sip.example.com.").
+/// CAA: "flags tag value" (e.g. "0 issue letsencrypt.org").
+/// </summary>
+public class SavedRecord
+{
+    public int Ttl { get; set; }
+    public List<string> Values { get; set; } = [];
+}

--- a/tests/DnsSync.Tests/Plan/PlanFileSerializerTests.cs
+++ b/tests/DnsSync.Tests/Plan/PlanFileSerializerTests.cs
@@ -1,0 +1,309 @@
+using DnsSync.Core;
+using DnsSync.Core.Records;
+using DnsSync.Plan;
+using Shouldly;
+
+namespace DnsSync.Tests.Plan;
+
+public class PlanFileSerializerTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static DnsPlan MakeSimplePlan() => new()
+    {
+        Changes =
+        [
+            new RecordChange
+            {
+                ChangeType = ChangeType.Create,
+                After = new ARecord { Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"] }
+            },
+            new RecordChange
+            {
+                ChangeType = ChangeType.Delete,
+                Before = new TxtRecord { Name = "example.com.", Type = "TXT", Ttl = 3600, Values = ["v=spf1 ~all"] }
+            },
+            new RecordChange
+            {
+                ChangeType = ChangeType.Update,
+                Before = new MxRecord { Name = "example.com.", Type = "MX", Ttl = 3600,
+                    Values = [new MxValue(10, "mail.example.com.")] },
+                After  = new MxRecord { Name = "example.com.", Type = "MX", Ttl = 300,
+                    Values = [new MxValue(10, "mail.example.com.")] }
+            }
+        ]
+    };
+
+    private static (string ConfigPath, string PlanPath) WriteTempFiles(string configContent = "providers: {}")
+    {
+        var configPath = Path.GetTempFileName();
+        var planPath   = Path.GetTempFileName();
+        File.WriteAllText(configPath, configContent);
+        return (configPath, planPath);
+    }
+
+    // ── Round-trip ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SaveAndLoad_RoundTrip_PreservesZoneAndTarget()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            var plan = MakeSimplePlan();
+            PlanFileSerializer.Save(configPath, [("example.com.", "cloudflare", plan)], planPath);
+
+            var body = PlanFileSerializer.Load(configPath, planPath);
+
+            body.Zones.ShouldHaveSingleItem();
+            body.Zones[0].Zone.ShouldBe("example.com.");
+            body.Zones[0].Target.ShouldBe("cloudflare");
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+
+    [Fact]
+    public void SaveAndLoad_RoundTrip_PreservesChangeCount()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            PlanFileSerializer.Save(configPath, [("example.com.", "cf", MakeSimplePlan())], planPath);
+            var body = PlanFileSerializer.Load(configPath, planPath);
+
+            body.Zones[0].Changes.Count.ShouldBe(3);
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+
+    [Fact]
+    public void SaveAndLoad_RoundTrip_PreservesChangeTypes()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            PlanFileSerializer.Save(configPath, [("example.com.", "cf", MakeSimplePlan())], planPath);
+            var body = PlanFileSerializer.Load(configPath, planPath);
+
+            var changes = body.Zones[0].Changes;
+            changes[0].Type.ShouldBe("create");
+            changes[1].Type.ShouldBe("delete");
+            changes[2].Type.ShouldBe("update");
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+
+    [Fact]
+    public void SaveAndLoad_RoundTrip_PreservesARecordValues()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            PlanFileSerializer.Save(configPath, [("example.com.", "cf", MakeSimplePlan())], planPath);
+            var body = PlanFileSerializer.Load(configPath, planPath);
+
+            var create = body.Zones[0].Changes[0];
+            create.After!.Ttl.ShouldBe(300);
+            create.After.Values.ShouldContain("1.2.3.4");
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+
+    [Fact]
+    public void SaveAndLoad_RoundTrip_PreservesMxEncoding()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            PlanFileSerializer.Save(configPath, [("example.com.", "cf", MakeSimplePlan())], planPath);
+            var body = PlanFileSerializer.Load(configPath, planPath);
+
+            var update = body.Zones[0].Changes[2];
+            update.Before!.Values.ShouldContain("10 mail.example.com.");
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+
+    // ── ToDnsPlan reconstruction ─────────────────────────────────────────────
+
+    [Fact]
+    public void ToDnsPlan_ReconstructsARecord()
+    {
+        var savedZone = new SavedZonePlan
+        {
+            Zone = "example.com.", Target = "cf",
+            Changes =
+            [
+                new SavedChange
+                {
+                    Type = "create", Name = "www.example.com.", RecordType = "A",
+                    After = new SavedRecord { Ttl = 300, Values = ["1.2.3.4", "5.6.7.8"] }
+                }
+            ]
+        };
+
+        var plan = PlanFileSerializer.ToDnsPlan(savedZone);
+
+        plan.Creates.ShouldBe(1);
+        var record = plan.Changes[0].After.ShouldBeOfType<ARecord>();
+        record.Addresses.ShouldContain("1.2.3.4");
+        record.Addresses.ShouldContain("5.6.7.8");
+        record.Ttl.ShouldBe(300);
+    }
+
+    [Fact]
+    public void ToDnsPlan_ReconstructsMxRecord()
+    {
+        var savedZone = new SavedZonePlan
+        {
+            Zone = "example.com.", Target = "cf",
+            Changes =
+            [
+                new SavedChange
+                {
+                    Type = "create", Name = "example.com.", RecordType = "MX",
+                    After = new SavedRecord { Ttl = 3600, Values = ["10 mail.example.com.", "20 mail2.example.com."] }
+                }
+            ]
+        };
+
+        var plan = PlanFileSerializer.ToDnsPlan(savedZone);
+
+        var record = plan.Changes[0].After.ShouldBeOfType<MxRecord>();
+        record.Values.Count.ShouldBe(2);
+        record.Values[0].Preference.ShouldBe(10);
+        record.Values[0].Exchange.ShouldBe("mail.example.com.");
+        record.Values[1].Preference.ShouldBe(20);
+    }
+
+    [Fact]
+    public void ToDnsPlan_ReconstructsSrvRecord()
+    {
+        var savedZone = new SavedZonePlan
+        {
+            Zone = "example.com.", Target = "cf",
+            Changes =
+            [
+                new SavedChange
+                {
+                    Type = "create", Name = "_sip._tcp.example.com.", RecordType = "SRV",
+                    After = new SavedRecord { Ttl = 300, Values = ["10 20 443 sip.example.com."] }
+                }
+            ]
+        };
+
+        var plan = PlanFileSerializer.ToDnsPlan(savedZone);
+
+        var record = plan.Changes[0].After.ShouldBeOfType<SrvRecord>();
+        record.Values[0].Priority.ShouldBe(10);
+        record.Values[0].Weight.ShouldBe(20);
+        record.Values[0].Port.ShouldBe(443);
+        record.Values[0].Target.ShouldBe("sip.example.com.");
+    }
+
+    [Fact]
+    public void ToDnsPlan_ReconstructsCaaRecord()
+    {
+        var savedZone = new SavedZonePlan
+        {
+            Zone = "example.com.", Target = "cf",
+            Changes =
+            [
+                new SavedChange
+                {
+                    Type = "create", Name = "example.com.", RecordType = "CAA",
+                    After = new SavedRecord { Ttl = 3600, Values = ["0 issue letsencrypt.org"] }
+                }
+            ]
+        };
+
+        var plan = PlanFileSerializer.ToDnsPlan(savedZone);
+
+        var record = plan.Changes[0].After.ShouldBeOfType<CaaRecord>();
+        record.Values[0].Flags.ShouldBe(0);
+        record.Values[0].Tag.ShouldBe("issue");
+        record.Values[0].Value.ShouldBe("letsencrypt.org");
+    }
+
+    // ── Signature verification ───────────────────────────────────────────────
+
+    [Fact]
+    public void Load_TamperedPlanContent_ThrowsInvalidOperation()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            PlanFileSerializer.Save(configPath, [("example.com.", "cf", MakeSimplePlan())], planPath);
+
+            // Tamper: replace a value inside the saved file
+            var content = File.ReadAllText(planPath);
+            content = content.Replace("1.2.3.4", "9.9.9.9");
+            File.WriteAllText(planPath, content);
+
+            Should.Throw<InvalidOperationException>(() =>
+                PlanFileSerializer.Load(configPath, planPath))
+                .Message.ShouldContain("tampered");
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+
+    [Fact]
+    public void Load_ChangedConfig_ThrowsInvalidOperation()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            PlanFileSerializer.Save(configPath, [("example.com.", "cf", MakeSimplePlan())], planPath);
+
+            // Change the config after saving the plan
+            File.WriteAllText(configPath, "providers: { changed: true }");
+
+            Should.Throw<InvalidOperationException>(() =>
+                PlanFileSerializer.Load(configPath, planPath))
+                .Message.ShouldContain("Config file has changed");
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+
+    [Fact]
+    public void Load_UnmodifiedPlan_DoesNotThrow()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            PlanFileSerializer.Save(configPath, [("example.com.", "cf", MakeSimplePlan())], planPath);
+            Should.NotThrow(() => PlanFileSerializer.Load(configPath, planPath));
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+
+    [Fact]
+    public void Load_MissingPlanFile_ThrowsFileNotFound()
+    {
+        var configPath = Path.GetTempFileName();
+        try
+        {
+            Should.Throw<FileNotFoundException>(() =>
+                PlanFileSerializer.Load(configPath, "/nonexistent/plan.yaml"));
+        }
+        finally { File.Delete(configPath); }
+    }
+
+    // ── YAML format sanity ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Save_WritesValidYamlWithSignatureField()
+    {
+        var (configPath, planPath) = WriteTempFiles();
+        try
+        {
+            PlanFileSerializer.Save(configPath, [("example.com.", "cf", MakeSimplePlan())], planPath);
+
+            var content = File.ReadAllText(planPath);
+            content.ShouldContain("signature:");
+            content.ShouldContain("sha256:");
+            content.ShouldContain("plan:");
+        }
+        finally { File.Delete(configPath); File.Delete(planPath); }
+    }
+}

--- a/tests/DnsSync.Tests/Plan/PlanFileSerializerTests.cs
+++ b/tests/DnsSync.Tests/Plan/PlanFileSerializerTests.cs
@@ -260,7 +260,7 @@ public class PlanFileSerializerTests
 
             Should.Throw<InvalidOperationException>(() =>
                 PlanFileSerializer.Load(configPath, planPath))
-                .Message.ShouldContain("Config file has changed");
+                .Message.ShouldContain("Config file has changed since this plan was generated");
         }
         finally { File.Delete(configPath); File.Delete(planPath); }
     }


### PR DESCRIPTION
## Summary

- Adds \`dns-sync plan --save-plan <path>\` — computes the plan and saves it as a signed YAML file
- Adds \`dns-sync apply --from-plan <path>\` — verifies the signature and applies exactly what was planned, skipping \`GetZoneAsync\` entirely
- Plan file uses YAML format with a \`signature\` field (HMAC-SHA256, key = SHA256 of the config file bytes)
- Two failure modes on \`apply --from-plan\`: config changed since plan was generated, or plan content was tampered with

## Plan file format

```yaml
plan:
  version: 1
  created_at: "2024-01-15T10:30:00Z"
  config_hash: "sha256:..."
  zones:
    - zone: example.com.
      target: cloudflare
      changes:
        - type: create
          name: www.example.com.
          record_type: A
          after:
            ttl: 300
            values: [1.2.3.4]
signature: "sha256:..."
```

## Test plan

- [ ] 14 new tests in \`PlanFileSerializerTests\`: round-trip for all record types, tamper detection, changed-config detection, YAML format sanity
- [ ] Full suite: 151/151 passing

Closes #16