### PR TITLE
feat: JSON Schema for zone files with CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
           name: coverage-report
           path: ./coverage/**/coverage.cobertura.xml
           retention-days: 14
+
+      - name: Validate zone JSON Schema
+        run: npx --yes ajv-cli@5 validate-schema -s schemas/zone.schema.json

--- a/schemas/zone.schema.json
+++ b/schemas/zone.schema.json
@@ -1,0 +1,289 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/cl8dep/dns-sync/main/schemas/zone.schema.json",
+  "title": "dns-sync Zone File",
+  "description": "Zone file format for dns-sync. Each key is a subdomain label (empty string or '@' for apex, relative labels like 'www', or absolute FQDNs ending with '.'). Each value is a single record object or a list of record objects.",
+  "type": "object",
+  "additionalProperties": {
+    "oneOf": [
+      { "$ref": "#/definitions/record" },
+      {
+        "type": "array",
+        "items": { "$ref": "#/definitions/record" },
+        "minItems": 1
+      }
+    ]
+  },
+  "definitions": {
+    "ttl": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647,
+      "description": "Time to live in seconds. Defaults to 3600 if omitted."
+    },
+    "record": {
+      "oneOf": [
+        { "$ref": "#/definitions/ARecord" },
+        { "$ref": "#/definitions/AAAARecord" },
+        { "$ref": "#/definitions/CNAMERecord" },
+        { "$ref": "#/definitions/MXRecord" },
+        { "$ref": "#/definitions/TXTRecord" },
+        { "$ref": "#/definitions/NSRecord" },
+        { "$ref": "#/definitions/CAARecord" },
+        { "$ref": "#/definitions/SRVRecord" }
+      ]
+    },
+    "ARecord": {
+      "type": "object",
+      "description": "IPv4 address record.",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "const": "A" },
+        "ttl": { "$ref": "#/definitions/ttl" },
+        "values": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Single IPv4 address."
+            },
+            {
+              "type": "array",
+              "description": "One or more IPv4 addresses.",
+              "items": { "type": "string" },
+              "minItems": 1
+            }
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Single IPv4 address (alias for values)."
+        }
+      },
+      "anyOf": [
+        { "required": ["values"] },
+        { "required": ["value"] }
+      ]
+    },
+    "AAAARecord": {
+      "type": "object",
+      "description": "IPv6 address record.",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "const": "AAAA" },
+        "ttl": { "$ref": "#/definitions/ttl" },
+        "values": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Single IPv6 address."
+            },
+            {
+              "type": "array",
+              "description": "One or more IPv6 addresses.",
+              "items": { "type": "string" },
+              "minItems": 1
+            }
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Single IPv6 address (alias for values)."
+        }
+      },
+      "anyOf": [
+        { "required": ["values"] },
+        { "required": ["value"] }
+      ]
+    },
+    "CNAMERecord": {
+      "type": "object",
+      "description": "Canonical name alias. Must point to an FQDN (trailing dot recommended).",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "const": "CNAME" },
+        "ttl": { "$ref": "#/definitions/ttl" },
+        "value": {
+          "type": "string",
+          "description": "Target FQDN (e.g. 'api.backend.example.com.')."
+        },
+        "target": {
+          "type": "string",
+          "description": "Target FQDN — alias for 'value'."
+        }
+      },
+      "anyOf": [
+        { "required": ["value"] },
+        { "required": ["target"] }
+      ]
+    },
+    "MXRecord": {
+      "type": "object",
+      "description": "Mail exchanger record.",
+      "required": ["type", "values"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "const": "MX" },
+        "ttl": { "$ref": "#/definitions/ttl" },
+        "values": {
+          "type": "array",
+          "description": "List of mail exchangers.",
+          "items": { "$ref": "#/definitions/MXValue" },
+          "minItems": 1
+        }
+      }
+    },
+    "MXValue": {
+      "type": "object",
+      "required": ["exchange"],
+      "additionalProperties": false,
+      "properties": {
+        "preference": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535,
+          "description": "Priority — lower value = higher priority. Defaults to 10.",
+          "default": 10
+        },
+        "exchange": {
+          "type": "string",
+          "description": "Mail server FQDN (e.g. 'mail.example.com.')."
+        }
+      }
+    },
+    "TXTRecord": {
+      "type": "object",
+      "description": "Text record. Used for SPF, DKIM, DMARC, domain verification, and arbitrary text.",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "const": "TXT" },
+        "ttl": { "$ref": "#/definitions/ttl" },
+        "values": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Single TXT string."
+            },
+            {
+              "type": "array",
+              "description": "Multiple TXT strings (separate RRset entries).",
+              "items": { "type": "string" },
+              "minItems": 1
+            }
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Single TXT string (alias for values)."
+        }
+      },
+      "anyOf": [
+        { "required": ["values"] },
+        { "required": ["value"] }
+      ]
+    },
+    "NSRecord": {
+      "type": "object",
+      "description": "Name server record. Apex NS records are excluded from diffs by default — use --include-apex-ns to override.",
+      "required": ["type", "values"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "const": "NS" },
+        "ttl": { "$ref": "#/definitions/ttl" },
+        "values": {
+          "type": "array",
+          "description": "List of nameserver FQDNs.",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      }
+    },
+    "CAARecord": {
+      "type": "object",
+      "description": "Certification Authority Authorization record. Controls which CAs may issue certificates for the domain.",
+      "required": ["type", "values"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "const": "CAA" },
+        "ttl": { "$ref": "#/definitions/ttl" },
+        "values": {
+          "type": "array",
+          "description": "List of CAA entries.",
+          "items": { "$ref": "#/definitions/CAAValue" },
+          "minItems": 1
+        }
+      }
+    },
+    "CAAValue": {
+      "type": "object",
+      "required": ["tag", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "flags": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
+          "description": "CAA flags byte. 0 = non-critical, 128 = critical. Defaults to 0.",
+          "default": 0
+        },
+        "tag": {
+          "type": "string",
+          "description": "CAA property tag.",
+          "enum": ["issue", "issuewild", "iodef"]
+        },
+        "value": {
+          "type": "string",
+          "description": "CA domain name for 'issue'/'issuewild', or mailto/URL for 'iodef'. Use ';' to deny all CAs."
+        }
+      }
+    },
+    "SRVRecord": {
+      "type": "object",
+      "description": "Service locator record. The subdomain key must follow the '_service._proto' convention (e.g. '_sip._tcp').",
+      "required": ["type", "values"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "const": "SRV" },
+        "ttl": { "$ref": "#/definitions/ttl" },
+        "values": {
+          "type": "array",
+          "description": "List of service endpoints.",
+          "items": { "$ref": "#/definitions/SRVValue" },
+          "minItems": 1
+        }
+      }
+    },
+    "SRVValue": {
+      "type": "object",
+      "required": ["priority", "weight", "port", "target"],
+      "additionalProperties": false,
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535,
+          "description": "Priority — lower value = higher priority."
+        },
+        "weight": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535,
+          "description": "Relative weight for load balancing among equal-priority entries."
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535,
+          "description": "TCP or UDP port of the service."
+        },
+        "target": {
+          "type": "string",
+          "description": "FQDN of the host providing the service. Use '.' to signal unavailability."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `schemas/zone.schema.json` (JSON Schema Draft 7) covering all 8 record types: A, AAAA, CNAME, MX, TXT, NS, CAA, SRV
- Validates required vs optional fields, TTL range, CAA tag enum, MX/SRV value ranges, and both single-record and list-of-records forms
- Adds CI step: `npx ajv-cli@5 validate-schema` — verifies the schema itself is valid Draft 7 on every push/PR
- Wiki: new [Editor Setup](https://github.com/cl8dep/dns-sync/wiki/Editor-Setup) page with VS Code (modeline + workspace settings) and JetBrains instructions

## Usage

Add to any zone file for instant editor validation and autocompletion:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/cl8dep/dns-sync/main/schemas/zone.schema.json

'':
  - type: A
    ttl: 3600
    values: [1.2.3.4]
```

Or configure via `.vscode/settings.json` to apply to all zone files automatically.

Closes #12