### PR TITLE
fix: normalize TXT record content for all providers

### DIFF
--- a/src/DnsSync/Core/Records/TxtRecord.cs
+++ b/src/DnsSync/Core/Records/TxtRecord.cs
@@ -21,4 +21,50 @@ public class TxtRecord : DnsRecord
     /// </summary>
     internal static string NormalizeTxtValue(string value) =>
         System.Text.RegularExpressions.Regex.Replace(value, @"\\(.)", "$1");
+
+    /// <summary>
+    /// Parse a TXT record content field as returned by DNS providers.
+    /// Handles quoted strings ("value"), backslash escapes, and RFC 4408
+    /// multi-chunk values ("chunk1" "chunk2" → "chunk1chunk2").
+    /// </summary>
+    internal static string ParseTxtContent(string content)
+    {
+        // If not quoted, return as-is (Porkbun sometimes returns raw unquoted values)
+        var trimmed = content.TrimStart();
+        if (trimmed.Length == 0 || trimmed[0] != '"') return content;
+
+        var result = new System.Text.StringBuilder();
+        var i = 0;
+        while (i < content.Length)
+        {
+            while (i < content.Length && content[i] == ' ') i++;
+            if (i >= content.Length) break;
+
+            if (content[i] == '"')
+            {
+                i++; // skip opening quote
+                while (i < content.Length && content[i] != '"')
+                {
+                    if (content[i] == '\\' && i + 1 < content.Length)
+                    {
+                        result.Append(content[i + 1]);
+                        i += 2;
+                    }
+                    else
+                    {
+                        result.Append(content[i]);
+                        i++;
+                    }
+                }
+                if (i < content.Length) i++; // skip closing quote
+            }
+            else
+            {
+                var start = i;
+                while (i < content.Length && content[i] != ' ') i++;
+                result.Append(content[start..i]);
+            }
+        }
+        return result.ToString();
+    }
 }

--- a/src/DnsSync/Providers/Cloudflare/CloudflareProvider.cs
+++ b/src/DnsSync/Providers/Cloudflare/CloudflareProvider.cs
@@ -396,7 +396,7 @@ public class CloudflareProvider : IProvider
                 Name = name,
                 Type = "TXT",
                 Ttl = ttl,
-                Values = [StripTxtQuotes(r.GetProperty("content").GetString()!)]
+                Values = [TxtRecord.ParseTxtContent(r.GetProperty("content").GetString()!)]
             },
             "NS" => new NsRecord
             {
@@ -619,48 +619,6 @@ public class CloudflareProvider : IProvider
         return body;
     }
 
-    /// <summary>
-    /// Cloudflare returns TXT record content as DNS wire-format quoted strings.
-    /// Long values (e.g. DKIM keys) are split into 255-byte chunks:
-    ///   "chunk1" "chunk2"
-    /// This method joins all chunks into a single plain string, handling backslash escapes.
-    /// </summary>
-    private static string StripTxtQuotes(string content)
-    {
-        var result = new System.Text.StringBuilder();
-        var i = 0;
-        while (i < content.Length)
-        {
-            while (i < content.Length && content[i] == ' ') i++;
-            if (i >= content.Length) break;
-
-            if (content[i] == '"')
-            {
-                i++; // skip opening quote
-                while (i < content.Length && content[i] != '"')
-                {
-                    if (content[i] == '\\' && i + 1 < content.Length)
-                    {
-                        result.Append(content[i + 1]);
-                        i += 2;
-                    }
-                    else
-                    {
-                        result.Append(content[i]);
-                        i++;
-                    }
-                }
-                if (i < content.Length) i++; // skip closing quote
-            }
-            else
-            {
-                var start = i;
-                while (i < content.Length && content[i] != ' ') i++;
-                result.Append(content[start..i]);
-            }
-        }
-        return result.ToString();
-    }
 }
 
 internal sealed class CloudflareRateLimitException : Exception { }

--- a/src/DnsSync/Providers/Porkbun/PorkbunProvider.cs
+++ b/src/DnsSync/Providers/Porkbun/PorkbunProvider.cs
@@ -257,7 +257,7 @@ public class PorkbunProvider : IProvider
                 Name = name,
                 Type = "TXT",
                 Ttl = ttl,
-                Values = [content.Trim('"')]
+                Values = [TxtRecord.ParseTxtContent(content)]
             },
 
             "NS" => new NsRecord

--- a/tests/DnsSync.Tests/Core/Records/RecordNormalizationTests.cs
+++ b/tests/DnsSync.Tests/Core/Records/RecordNormalizationTests.cs
@@ -116,6 +116,17 @@ public class RecordNormalizationTests
         withDot.CanonicalHash().ShouldBe(withoutDot.CanonicalHash());
     }
 
+    [Theory]
+    [InlineData("v=spf1 ~all", "v=spf1 ~all")]
+    [InlineData("\"v=spf1 ~all\"", "v=spf1 ~all")]
+    [InlineData("\"chunk1\" \"chunk2\"", "chunk1chunk2")]
+    [InlineData("\"val\\;ue\"", "val;ue")]
+    [InlineData("\"a\" \"b\" \"c\"", "abc")]
+    public void TxtRecord_ParseTxtContent_NormalizesCorrectly(string input, string expected)
+    {
+        TxtRecord.ParseTxtContent(input).ShouldBe(expected);
+    }
+
     [Fact]
     public void CaaRecord_CanonicalHash_IsOrderIndependent()
     {

--- a/tests/DnsSync.Tests/Providers/Cloudflare/CloudflareParsingTests.cs
+++ b/tests/DnsSync.Tests/Providers/Cloudflare/CloudflareParsingTests.cs
@@ -8,21 +8,6 @@ namespace DnsSync.Tests.Providers.Cloudflare;
 
 public class CloudflareParsingTests
 {
-    // CloudflareProvider.StripTxtQuotes is private — test via ParseZoneYaml or directly via reflection
-    // Instead we test the public behaviour through the internal static helper exposed for tests.
-    // We use the public GcpCloudDnsProvider.UnquoteTxt as reference and test Cloudflare
-    // parsing by constructing a minimal provider and exercising ParseCloudflareRecord via
-    // the existing MergeIntoRRsets path through GetZoneAsync is impractical without HTTP mocks.
-    // We therefore test StripTxtQuotes indirectly through the CloudflareProvider's parsing
-    // by calling it through the non-public method via reflection.
-
-    private static string InvokeStripTxtQuotes(string input)
-    {
-        var method = typeof(CloudflareProvider)
-            .GetMethod("StripTxtQuotes",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-        return (string)method.Invoke(null, [input])!;
-    }
 
     private static JsonElement MakeRecord(string type, string name, int ttl, string content,
         int? priority = null, string? data = null)
@@ -58,46 +43,46 @@ public class CloudflareParsingTests
         return (DnsRecord?)method.Invoke(provider, [el, zoneName]);
     }
 
-    // ─── StripTxtQuotes ───────────────────────────────────────────────────────
+    // ─── TxtRecord.ParseTxtContent ────────────────────────────────────────────
 
     [Fact]
-    public void StripTxtQuotes_SimpleSingleChunk_ReturnsPlainString()
+    public void ParseTxtContent_SimpleSingleChunk_ReturnsPlainString()
     {
-        InvokeStripTxtQuotes("\"v=spf1 include:example.com ~all\"")
+        TxtRecord.ParseTxtContent("\"v=spf1 include:example.com ~all\"")
             .ShouldBe("v=spf1 include:example.com ~all");
     }
 
     [Fact]
-    public void StripTxtQuotes_TwoChunks_JoinsChunks()
+    public void ParseTxtContent_TwoChunks_JoinsChunks()
     {
-        InvokeStripTxtQuotes("\"chunk1\" \"chunk2\"")
+        TxtRecord.ParseTxtContent("\"chunk1\" \"chunk2\"")
             .ShouldBe("chunk1chunk2");
     }
 
     [Fact]
-    public void StripTxtQuotes_EscapedQuoteInsideChunk_IsPreserved()
+    public void ParseTxtContent_EscapedQuoteInsideChunk_IsPreserved()
     {
-        InvokeStripTxtQuotes("\"hello \\\"world\\\"\"")
+        TxtRecord.ParseTxtContent("\"hello \\\"world\\\"\"")
             .ShouldBe("hello \"world\"");
     }
 
     [Fact]
-    public void StripTxtQuotes_UnquotedSingleToken_ReturnedAsIs()
+    public void ParseTxtContent_UnquotedSingleToken_ReturnedAsIs()
     {
-        InvokeStripTxtQuotes("plainvalue")
+        TxtRecord.ParseTxtContent("plainvalue")
             .ShouldBe("plainvalue");
     }
 
     [Fact]
-    public void StripTxtQuotes_EmptyString_ReturnsEmpty()
+    public void ParseTxtContent_EmptyString_ReturnsEmpty()
     {
-        InvokeStripTxtQuotes("\"\"").ShouldBe("");
+        TxtRecord.ParseTxtContent("\"\"").ShouldBe("");
     }
 
     [Fact]
-    public void StripTxtQuotes_BackslashEscape_IsHandled()
+    public void ParseTxtContent_BackslashEscape_IsHandled()
     {
-        InvokeStripTxtQuotes("\"back\\\\slash\"").ShouldBe("back\\slash");
+        TxtRecord.ParseTxtContent("\"back\\\\slash\"").ShouldBe("back\\slash");
     }
 
     // ─── Record parsing ───────────────────────────────────────────────────────

--- a/tests/DnsSync.Tests/Providers/Porkbun/PorkbunParsingTests.cs
+++ b/tests/DnsSync.Tests/Providers/Porkbun/PorkbunParsingTests.cs
@@ -145,6 +145,24 @@ public class PorkbunParsingTests
     }
 
     [Fact]
+    public void ParsePorkbunRecord_TxtRecord_MultiChunkJoined()
+    {
+        var el = MakeRecord("TXT", "example.com", "\"chunk1\" \"chunk2\"");
+        var record = PorkbunProvider.ParsePorkbunRecord(el, Zone) as TxtRecord;
+        record.ShouldNotBeNull();
+        record.Values[0].ShouldBe("chunk1chunk2");
+    }
+
+    [Fact]
+    public void ParsePorkbunRecord_TxtRecord_BackslashEscapeHandled()
+    {
+        var el = MakeRecord("TXT", "example.com", "\"val\\;ue\"");
+        var record = PorkbunProvider.ParsePorkbunRecord(el, Zone) as TxtRecord;
+        record.ShouldNotBeNull();
+        record.Values[0].ShouldBe("val;ue");
+    }
+
+    [Fact]
     public void ParsePorkbunRecord_UnknownType_ReturnsNull()
     {
         var el = MakeRecord("TLSA", "example.com", "0 0 1 abc123");


### PR DESCRIPTION
Fixes #28.

## Problem

After a successful `dns-sync apply`, running `plan` again reported a false TXT diff:

```
~ araelespinosa.dev.   TXT   600
  before: "apple-domain=Y6ghd3wxkTr17fu3" | "v=spf1 include:icloud.com ~all"
  after:  "v=spf1 include:icloud.com ~all"
```

Root cause: `content.Trim('"')` in `PorkbunProvider.ParsePorkbunRecord` was insufficient. It failed to handle:
- Backslash-escaped characters (`"val\;ue"`)
- RFC 4408 multi-chunk values (`"chunk1" "chunk2"` → `chunk1chunk2`)

## Fix

Extracted `CloudflareProvider.StripTxtQuotes` into a shared `TxtRecord.ParseTxtContent` method and used it in both providers. Unquoted values (Porkbun sometimes returns raw strings without quotes) are returned as-is.

## Changes

- `TxtRecord.cs` — add `internal static ParseTxtContent`
- `CloudflareProvider.cs` — use `TxtRecord.ParseTxtContent`, remove duplicate `StripTxtQuotes`
- `PorkbunProvider.cs` — replace `content.Trim('"')` with `TxtRecord.ParseTxtContent`
- Tests — cover multi-chunk, backslash escapes, quoted/unquoted variants (158 total, all pass)