### PR TITLE
fix: validate MX exchange values in ZoneValidator

### DIFF
--- a/src/DnsSync/Validation/ZoneValidator.cs
+++ b/src/DnsSync/Validation/ZoneValidator.cs
@@ -84,6 +84,15 @@ public static class ZoneValidator
                 case MxRecord mx:
                     if (mx.Values.Count == 0)
                         result.AddError($"{record.Name} MX: no values defined");
+                    foreach (var v in mx.Values)
+                    {
+                        if (string.IsNullOrWhiteSpace(v.Exchange) || v.Exchange == ".")
+                            result.AddError($"{record.Name} MX: exchange value is empty");
+                        else if (!IsValidHostname(v.Exchange))
+                            result.AddError($"{record.Name} MX: '{v.Exchange}' is not a valid hostname");
+                        if (v.Preference is < 0 or > 65535)
+                            result.AddError($"{record.Name} MX: priority {v.Preference} is out of range (0–65535)");
+                    }
                     types.Add("MX");
                     break;
 

--- a/tests/DnsSync.Tests/Providers/Yaml/YamlProviderTests.cs
+++ b/tests/DnsSync.Tests/Providers/Yaml/YamlProviderTests.cs
@@ -1,5 +1,6 @@
 using DnsSync.Core.Records;
 using DnsSync.Providers.Yaml;
+using DnsSync.Validation;
 using Shouldly;
 
 namespace DnsSync.Tests.Providers.Yaml;
@@ -179,5 +180,66 @@ public class YamlProviderTests
 
         records.Count.ShouldBe(1);
         records[0].Name.ShouldBe("api.example.com.");  // not api.example.com..example.com.
+    }
+
+    [Fact]
+    public void ParseZoneYaml_MxDotOnlyExchange_FailsValidation()
+    {
+        var yaml = """
+            '':
+              type: MX
+              ttl: 600
+              values:
+                - preference: 10
+                  exchange: .
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        var zone = new DnsSync.Core.DnsZone { Name = "example.com.", Records = records };
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Contains("MX") && e.Contains("exchange") && e.Contains("empty"));
+    }
+
+    [Fact]
+    public void ParseZoneYaml_MxEmptyExchange_FailsValidation()
+    {
+        var yaml = """
+            '':
+              type: MX
+              ttl: 600
+              values:
+                - preference: 10
+                  exchange: ''
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        var zone = new DnsSync.Core.DnsZone { Name = "example.com.", Records = records };
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Contains("MX") && e.Contains("exchange") && e.Contains("empty"));
+    }
+
+    [Fact]
+    public void ParseZoneYaml_MxValidExchanges_PassesValidation()
+    {
+        var yaml = """
+            '':
+              type: MX
+              ttl: 600
+              values:
+                - preference: 10
+                  exchange: mx01.mail.icloud.com.
+                - preference: 20
+                  exchange: mx02.mail.icloud.com.
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        var zone = new DnsSync.Core.DnsZone { Name = "example.com.", Records = records };
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeTrue();
     }
 }

--- a/tests/DnsSync.Tests/Validation/ZoneValidatorTests.cs
+++ b/tests/DnsSync.Tests/Validation/ZoneValidatorTests.cs
@@ -294,4 +294,114 @@ public class ZoneValidatorTests
         result.IsValid.ShouldBeFalse();
         result.Errors.ShouldContain(e => e.Contains("SRV") && e.Contains("port") && e.Contains("out of range"));
     }
+
+    [Fact]
+    public void Validate_MxEmptyExchange_ReturnsError()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 600,
+            Values = [new MxValue(10, "")]
+        });
+
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Contains("MX") && e.Contains("exchange") && e.Contains("empty"));
+    }
+
+    [Fact]
+    public void Validate_MxDotOnlyExchange_ReturnsError()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 600,
+            Values = [new MxValue(10, ".")]
+        });
+
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Contains("MX") && e.Contains("exchange") && e.Contains("empty"));
+    }
+
+    [Fact]
+    public void Validate_MxInvalidHostname_ReturnsError()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 600,
+            Values = [new MxValue(10, "-bad.example.com.")]
+        });
+
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Contains("MX") && e.Contains("not a valid hostname"));
+    }
+
+    [Fact]
+    public void Validate_MxOutOfRangePriority_ReturnsError()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 600,
+            Values = [new MxValue(70000, "mail.example.com.")]
+        });
+
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Contains("MX") && e.Contains("priority") && e.Contains("out of range"));
+    }
+
+    [Fact]
+    public void Validate_MxOneInvalidValueAmongMany_ReportsOnlyThatOne()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 600,
+            Values =
+            [
+                new MxValue(10, "mail.example.com."),
+                new MxValue(20, ".")
+            ]
+        });
+
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].ShouldContain("exchange");
+    }
+
+    [Fact]
+    public void Validate_MxValidValues_IsValid()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 600,
+            Values =
+            [
+                new MxValue(10, "mx1.example.com."),
+                new MxValue(20, "mx2.example.com.")
+            ]
+        });
+
+        var result = ZoneValidator.Validate(zone);
+
+        result.IsValid.ShouldBeTrue();
+    }
 }


### PR DESCRIPTION
Fixes #27.

## Problem

MX records with empty or dot-only exchange values (e.g. `exchange: .`) passed validation and reached Porkbun's API, which rejected them with:

```
Porkbun API returned 400: {"status":"ERROR","message":"Create error: Your DNS record must have an answer."}
```

This caused partial applies (some records succeed, one fails), leaving the zone in an inconsistent state.

## Fix

Added per-value validation to the `MxRecord` case in `ZoneValidator`:
- Empty or dot-only exchange → error
- Invalid hostname format → error  
- Priority out of range (0–65535) → error

Reuses the existing `IsValidHostname` helper already used by CNAME validation.

## Tests

- 6 new unit tests in `ZoneValidatorTests.cs` covering all new validation rules
- 3 integration tests in `YamlProviderTests.cs` exercising the full YAML → parse → validate path (the same path hit by `dns-sync validate`)
- 167 total tests, all pass