### PR TITLE
feat: dns-sync diff command — compare two providers directly

### DIFF
--- a/src/DnsSync/Commands/DiffCommand.cs
+++ b/src/DnsSync/Commands/DiffCommand.cs
@@ -1,0 +1,195 @@
+using System.Text.Json;
+using DnsSync.Core;
+using DnsSync.Providers;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace DnsSync.Commands;
+
+public class DiffCommand(ILoggerFactory loggerFactory) : AsyncCommand<DiffSettings>
+{
+    protected override async Task<int> ExecuteAsync(CommandContext context, DiffSettings settings, CancellationToken cancellationToken)
+    {
+        var jsonMode = string.Equals(settings.Output, "json", StringComparison.OrdinalIgnoreCase);
+        var useSpinners = !jsonMode && !settings.GcpLogs && !settings.Verbose;
+
+        try
+        {
+            var config = CommandHelpers.LoadAndValidateConfig(settings);
+
+            if (string.IsNullOrWhiteSpace(settings.From))
+            {
+                AnsiConsole.MarkupLine("[red]✗[/] --from is required.");
+                return 1;
+            }
+
+            if (string.IsNullOrWhiteSpace(settings.To))
+            {
+                AnsiConsole.MarkupLine("[red]✗[/] --to is required.");
+                return 1;
+            }
+
+            if (!config.Providers.TryGetValue(settings.From, out var fromConfig))
+            {
+                AnsiConsole.MarkupLine($"[red]✗[/] Provider '{Markup.Escape(settings.From)}' not found in config.");
+                return 1;
+            }
+
+            if (!config.Providers.TryGetValue(settings.To, out var toConfig))
+            {
+                AnsiConsole.MarkupLine($"[red]✗[/] Provider '{Markup.Escape(settings.To)}' not found in config.");
+                return 1;
+            }
+
+            if (string.Equals(settings.From, settings.To, StringComparison.OrdinalIgnoreCase))
+            {
+                AnsiConsole.MarkupLine("[red]✗[/] --from and --to must be different providers.");
+                return 1;
+            }
+
+            var fromProvider = ProviderFactory.Create(settings.From, fromConfig, loggerFactory);
+            var toProvider = ProviderFactory.Create(settings.To, toConfig, loggerFactory);
+
+            if (!jsonMode)
+                AnsiConsole.MarkupLine("\nRunning pre-flight checks...");
+
+            if (useSpinners)
+            {
+                await AnsiConsole.Status().StartAsync(
+                    $"Checking '{settings.From}'...",
+                    async ctx => { ctx.Spinner(Spinner.Known.Dots); await fromProvider.PreflightAsync(cancellationToken); });
+                await AnsiConsole.Status().StartAsync(
+                    $"Checking '{settings.To}'...",
+                    async ctx => { ctx.Spinner(Spinner.Known.Dots); await toProvider.PreflightAsync(cancellationToken); });
+            }
+            else
+            {
+                await fromProvider.PreflightAsync(cancellationToken);
+                await toProvider.PreflightAsync(cancellationToken);
+            }
+
+            if (!jsonMode)
+            {
+                AnsiConsole.MarkupLine($"[green]✓[/] '{Markup.Escape(settings.From)}' reachable");
+                AnsiConsole.MarkupLine($"[green]✓[/] '{Markup.Escape(settings.To)}' reachable");
+            }
+
+            // Determine which zones to compare
+            IReadOnlyList<string> zones;
+            if (!string.IsNullOrEmpty(settings.Zone))
+            {
+                zones = [settings.Zone];
+            }
+            else
+            {
+                if (useSpinners)
+                    zones = await AnsiConsole.Status().StartAsync(
+                        $"Discovering zones from '{settings.From}'...",
+                        async ctx => { ctx.Spinner(Spinner.Known.Dots); return await fromProvider.GetZonesAsync(cancellationToken); });
+                else
+                    zones = await fromProvider.GetZonesAsync(cancellationToken);
+
+                if (!jsonMode)
+                    AnsiConsole.MarkupLine($"[green]✓[/] Found [bold]{zones.Count}[/] zone(s) in '{Markup.Escape(settings.From)}'");
+            }
+
+            var totalChanges = 0;
+            var hasErrors = false;
+            var jsonZones = new List<object>();
+
+            foreach (var zoneName in zones)
+            {
+                try
+                {
+                    DnsZone fromZone;
+                    if (useSpinners)
+                        fromZone = await AnsiConsole.Status().StartAsync(
+                            $"Fetching {zoneName} from '{settings.From}'...",
+                            async ctx => { ctx.Spinner(Spinner.Known.Dots); return await fromProvider.GetZoneAsync(zoneName, cancellationToken); });
+                    else
+                        fromZone = await fromProvider.GetZoneAsync(zoneName, cancellationToken);
+
+                    DnsZone toZone;
+                    try
+                    {
+                        if (useSpinners)
+                            toZone = await AnsiConsole.Status().StartAsync(
+                                $"Fetching {zoneName} from '{settings.To}'...",
+                                async ctx => { ctx.Spinner(Spinner.Known.Dots); return await toProvider.GetZoneAsync(zoneName, cancellationToken); });
+                        else
+                            toZone = await toProvider.GetZoneAsync(zoneName, cancellationToken);
+                    }
+                    catch
+                    {
+                        // Zone doesn't exist on target — treat as empty (all records = creates)
+                        toZone = new DnsZone { Name = zoneName, Records = [] };
+                        if (!jsonMode)
+                            AnsiConsole.MarkupLine(
+                                $"  [yellow]~[/] Zone '{Markup.Escape(zoneName)}' not found in '{Markup.Escape(settings.To)}' — treating as empty");
+                    }
+
+                    var plan = ZoneDiff.Diff(fromZone, toZone, settings.IncludeApexNs);
+
+                    if (jsonMode)
+                        jsonZones.Add(BuildJsonDiff(zoneName, settings.From, settings.To, plan));
+                    else
+                        CommandHelpers.PrintPlan(plan, zoneName, settings.To, settings.Wide);
+
+                    totalChanges += plan.Total;
+                }
+                catch (Exception ex)
+                {
+                    if (!jsonMode)
+                        AnsiConsole.MarkupLine(
+                            $"[red]✗[/] Zone '{Markup.Escape(zoneName)}': {Markup.Escape(ex.Message)}");
+                    hasErrors = true;
+                }
+            }
+
+            if (jsonMode)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(jsonZones, new JsonSerializerOptions { WriteIndented = true }));
+            }
+            else
+            {
+                if (totalChanges > 0)
+                    AnsiConsole.MarkupLine(
+                        $"\n[bold]{totalChanges} difference(s) found[/] between '{Markup.Escape(settings.From)}' and '{Markup.Escape(settings.To)}'.");
+                else if (!hasErrors)
+                    AnsiConsole.MarkupLine(
+                        $"\n[green]✓ Providers '{Markup.Escape(settings.From)}' and '{Markup.Escape(settings.To)}' are in sync.[/]");
+            }
+
+            return hasErrors ? 1 : (settings.ExitCode && totalChanges > 0 ? 2 : 0);
+        }
+        catch (Exception ex)
+        {
+            CommandHelpers.PrintError(ex, settings.Verbose);
+            return 1;
+        }
+    }
+
+    private static object BuildJsonDiff(string zoneName, string fromName, string toName, DnsPlan plan)
+    {
+        var changes = plan.Changes.Select(c => new
+        {
+            type = c.ChangeType.ToString().ToLowerInvariant(),
+            record_name = (c.After ?? c.Before)?.Name,
+            record_type = (c.After ?? c.Before)?.Type,
+            before = c.Before?.FormatValues(),
+            after = c.After?.FormatValues()
+        }).ToList();
+
+        return new
+        {
+            zone = zoneName,
+            from = fromName,
+            to = toName,
+            creates = plan.Creates,
+            updates = plan.Updates,
+            deletes = plan.Deletes,
+            changes
+        };
+    }
+}

--- a/src/DnsSync/Commands/DiffSettings.cs
+++ b/src/DnsSync/Commands/DiffSettings.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace DnsSync.Commands;
+
+public class DiffSettings : BaseSettings
+{
+    [CommandOption("--from <PROVIDER>")]
+    [Description("Source provider name from config (read from)")]
+    public string From { get; set; } = string.Empty;
+
+    [CommandOption("--to <PROVIDER>")]
+    [Description("Target provider name from config (compare against)")]
+    public string To { get; set; } = string.Empty;
+
+    [CommandOption("-z|--zone <ZONE>")]
+    [Description("Compare a single zone (e.g. example.com.) — if omitted, discovers all zones from --from provider")]
+    public string? Zone { get; set; }
+
+    [CommandOption("--include-apex-ns")]
+    [Description("Include apex NS records in the diff (excluded by default to prevent registrar conflicts)")]
+    public bool IncludeApexNs { get; set; }
+
+    [CommandOption("--wide")]
+    [Description("Show record values on a second line (no truncation)")]
+    public bool Wide { get; set; }
+
+    [CommandOption("--output <FORMAT>")]
+    [Description("Output format: text (default) or json")]
+    [DefaultValue("text")]
+    public string Output { get; set; } = "text";
+
+    [CommandOption("--exit-code")]
+    [Description("Return exit code 2 when there are differences (Terraform-compatible)")]
+    public bool ExitCode { get; set; }
+}

--- a/src/DnsSync/Program.cs
+++ b/src/DnsSync/Program.cs
@@ -142,6 +142,11 @@ app.Configure(config =>
     config.AddCommand<ImportCommand>("import")
         .WithDescription("Import current DNS state from a provider into YAML zone files")
         .WithExample(["import", "--config", "config.yaml", "--provider", "cloudflare", "--all"]);
+
+    config.AddCommand<DiffCommand>("diff")
+        .WithDescription("Compare DNS state between two providers directly (read-only)")
+        .WithExample(["diff", "--from", "cloudflare", "--to", "route53", "--config", "config.yaml"])
+        .WithExample(["diff", "--from", "cloudflare", "--to", "porkbun", "--zone", "example.com.", "--config", "config.yaml"]);
 });
 
 return await app.RunAsync(args);

--- a/tests/DnsSync.Tests/Commands/DiffCommandTests.cs
+++ b/tests/DnsSync.Tests/Commands/DiffCommandTests.cs
@@ -1,0 +1,155 @@
+using DnsSync.Core;
+using DnsSync.Core.Records;
+using Shouldly;
+
+namespace DnsSync.Tests.Commands;
+
+/// <summary>
+/// Tests for the diff command logic: zone discovery, empty-target handling, and plan production.
+/// These tests exercise ZoneDiff directly with stub zones, matching what DiffCommand does internally.
+/// </summary>
+public class DiffCommandTests
+{
+    private static DnsZone ZoneWith(string name, params DnsRecord[] records) =>
+        new() { Name = name, Records = records };
+
+    private static DnsZone EmptyZone(string name) =>
+        new() { Name = name, Records = [] };
+
+    // ─── Both zones identical ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_IdenticalZones_ProducesNoPlan()
+    {
+        var from = ZoneWith("example.com.",
+            new ARecord { Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"] });
+        var to = ZoneWith("example.com.",
+            new ARecord { Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"] });
+
+        var plan = ZoneDiff.Diff(from, to);
+
+        plan.IsEmpty.ShouldBeTrue();
+        plan.Total.ShouldBe(0);
+    }
+
+    // ─── Record in from but not in to ─────────────────────────────────────────
+
+    [Fact]
+    public void Diff_RecordInFromNotInTo_ProducesCreate()
+    {
+        var from = ZoneWith("example.com.",
+            new ARecord { Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"] });
+        var to = EmptyZone("example.com.");
+
+        var plan = ZoneDiff.Diff(from, to);
+
+        plan.Creates.ShouldBe(1);
+        plan.Updates.ShouldBe(0);
+        plan.Deletes.ShouldBe(0);
+        plan.Changes[0].ChangeType.ShouldBe(ChangeType.Create);
+        plan.Changes[0].After.ShouldBeOfType<ARecord>();
+    }
+
+    // ─── Record in to but not in from ─────────────────────────────────────────
+
+    [Fact]
+    public void Diff_RecordInToNotInFrom_ProducesDelete()
+    {
+        var from = EmptyZone("example.com.");
+        var to = ZoneWith("example.com.",
+            new ARecord { Name = "old.example.com.", Type = "A", Ttl = 300, Addresses = ["9.9.9.9"] });
+
+        var plan = ZoneDiff.Diff(from, to);
+
+        plan.Deletes.ShouldBe(1);
+        plan.Changes[0].ChangeType.ShouldBe(ChangeType.Delete);
+    }
+
+    // ─── Records differ between providers ────────────────────────────────────
+
+    [Fact]
+    public void Diff_RecordValuesDiffer_ProducesUpdate()
+    {
+        var from = ZoneWith("example.com.",
+            new ARecord { Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"] });
+        var to = ZoneWith("example.com.",
+            new ARecord { Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["9.9.9.9"] });
+
+        var plan = ZoneDiff.Diff(from, to);
+
+        plan.Updates.ShouldBe(1);
+        plan.Changes[0].ChangeType.ShouldBe(ChangeType.Update);
+        plan.Changes[0].IsTtlOnlyChange.ShouldBeFalse();
+    }
+
+    // ─── Target zone not found → treated as empty ────────────────────────────
+
+    [Fact]
+    public void Diff_TargetZoneNotFound_AllRecordsAreCreates()
+    {
+        var from = ZoneWith("example.com.",
+            new ARecord { Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"] },
+            new MxRecord { Name = "example.com.", Type = "MX", Ttl = 600, Values = [new MxValue(10, "mail.example.com.")] });
+
+        // Simulate target zone not found: substitute empty zone (DiffCommand behavior)
+        var to = EmptyZone("example.com.");
+
+        var plan = ZoneDiff.Diff(from, to);
+
+        plan.Creates.ShouldBe(2);
+        plan.Deletes.ShouldBe(0);
+    }
+
+    // ─── Multiple record types ────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_MultipleRecordTypes_EachDiffedIndependently()
+    {
+        var from = ZoneWith("example.com.",
+            new ARecord { Name = "example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"] },
+            new TxtRecord { Name = "example.com.", Type = "TXT", Ttl = 300, Values = ["v=spf1 ~all"] },
+            new MxRecord { Name = "example.com.", Type = "MX", Ttl = 600, Values = [new MxValue(10, "mail.example.com.")] });
+
+        var to = ZoneWith("example.com.",
+            new ARecord { Name = "example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"] },  // same
+            new TxtRecord { Name = "example.com.", Type = "TXT", Ttl = 300, Values = ["v=spf1 include:sendgrid.net ~all"] }); // changed — MX missing
+
+        var plan = ZoneDiff.Diff(from, to);
+
+        plan.Creates.ShouldBe(1);  // MX
+        plan.Updates.ShouldBe(1);  // TXT
+        plan.Deletes.ShouldBe(0);
+    }
+
+    // ─── --include-apex-ns flag ───────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_ApexNsExcludedByDefault()
+    {
+        var from = ZoneWith("example.com.",
+            new NsRecord { Name = "example.com.", Type = "NS", Ttl = 3600, Nameservers = ["ns1.from.com.", "ns2.from.com."] });
+        var to = ZoneWith("example.com.",
+            new NsRecord { Name = "example.com.", Type = "NS", Ttl = 3600, Nameservers = ["ns1.to.com.", "ns2.to.com."] });
+
+        var planExcluded = ZoneDiff.Diff(from, to, includeApexNs: false);
+        var planIncluded = ZoneDiff.Diff(from, to, includeApexNs: true);
+
+        planExcluded.IsEmpty.ShouldBeTrue();
+        planIncluded.Updates.ShouldBe(1);
+    }
+
+    // ─── TXT record normalization ─────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_TxtRecordsIdentical_NoDiff()
+    {
+        var from = ZoneWith("example.com.",
+            new TxtRecord { Name = "_dmarc.example.com.", Type = "TXT", Ttl = 300, Values = ["v=DMARC1; p=reject"] });
+        var to = ZoneWith("example.com.",
+            new TxtRecord { Name = "_dmarc.example.com.", Type = "TXT", Ttl = 300, Values = ["v=DMARC1; p=reject"] });
+
+        var plan = ZoneDiff.Diff(from, to);
+
+        plan.IsEmpty.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `dns-sync diff` — a read-only command that compares DNS state between two live providers without requiring a YAML source file. Useful for verifying migrations and auditing provider drift.

Closes #14

## Usage

```bash
# Compare all zones from cloudflare against route53
dns-sync diff -c config.yaml --from cloudflare --to route53

# Compare a specific zone
dns-sync diff -c config.yaml --from cloudflare --to porkbun --zone example.com.

# JSON output for CI
dns-sync diff -c config.yaml --from cloudflare --to porkbun --output json --exit-code
```

## Implementation notes

- Reuses `ZoneDiff.Diff`, `CommandHelpers.PrintPlan`, and `ProviderFactory.Create` unchanged
- If `--zone` is omitted, discovers zones via `GetZonesAsync` on the `--from` provider
- If a zone exists in `--from` but not in `--to`, treats target as empty (all records = creates)
- `--exit-code` returns 2 when differences exist (Terraform-compatible)
- Output format identical to `dns-sync plan`

## Test plan

- [ ] `dotnet test` — all 180 tests pass
- [ ] `dns-sync diff --help` shows correct flags and examples
- [ ] Manual: `dns-sync diff --from cloudflare --to porkbun --zone example.com.`
- [ ] Manual: `dns-sync diff --from godaddy --to porkbun --all` (zone discovery)
- [ ] `--output json` produces valid JSON with `from`/`to`/`zone`/`changes` fields