### PR TITLE
dx: add short flag aliases for common CLI options

### DIFF
--- a/src/DnsSync/Commands/ApplySettings.cs
+++ b/src/DnsSync/Commands/ApplySettings.cs
@@ -14,7 +14,7 @@ public class ApplySettings : PlanSettings
     [DefaultValue(50)]
     public int MaxChanges { get; set; } = 50;
 
-    [CommandOption("--force")]
+    [CommandOption("-f|--force")]
     [Description("Override --max-changes safety limit")]
     public bool Force { get; set; }
 

--- a/src/DnsSync/Commands/DiffSettings.cs
+++ b/src/DnsSync/Commands/DiffSettings.cs
@@ -21,11 +21,11 @@ public class DiffSettings : BaseSettings
     [Description("Include apex NS records in the diff (excluded by default to prevent registrar conflicts)")]
     public bool IncludeApexNs { get; set; }
 
-    [CommandOption("--wide")]
+    [CommandOption("-w|--wide")]
     [Description("Show record values on a second line (no truncation)")]
     public bool Wide { get; set; }
 
-    [CommandOption("--output <FORMAT>")]
+    [CommandOption("-o|--output <FORMAT>")]
     [Description("Output format: text (default) or json")]
     [DefaultValue("text")]
     public string Output { get; set; } = "text";

--- a/src/DnsSync/Commands/ImportSettings.cs
+++ b/src/DnsSync/Commands/ImportSettings.cs
@@ -13,7 +13,7 @@ public class ImportSettings : BaseSettings
     [Description("Import a single zone (e.g. example.com.)")]
     public string? Zone { get; set; }
 
-    [CommandOption("--all")]
+    [CommandOption("-a|--all")]
     [Description("Import all zones from the provider")]
     public bool All { get; set; }
 
@@ -22,7 +22,7 @@ public class ImportSettings : BaseSettings
     [DefaultValue("./zones")]
     public string Output { get; set; } = "./zones";
 
-    [CommandOption("--force")]
+    [CommandOption("-f|--force")]
     [Description("Overwrite existing zone files")]
     public bool Force { get; set; }
 }

--- a/src/DnsSync/Commands/PlanSettings.cs
+++ b/src/DnsSync/Commands/PlanSettings.cs
@@ -5,7 +5,7 @@ namespace DnsSync.Commands;
 
 public class PlanSettings : BaseSettings
 {
-    [CommandOption("--wide")]
+    [CommandOption("-w|--wide")]
     [Description("Show record values on a second line (no truncation)")]
     public bool Wide { get; set; }
 
@@ -17,7 +17,7 @@ public class PlanSettings : BaseSettings
     [Description("Return exit code 2 when there are pending changes (Terraform-compatible)")]
     public bool ExitCode { get; set; }
 
-    [CommandOption("--output <FORMAT>")]
+    [CommandOption("-o|--output <FORMAT>")]
     [Description("Output format: text (default) or json")]
     [DefaultValue("text")]
     public string Output { get; set; } = "text";


### PR DESCRIPTION
## Summary

- Adds `-f` alias for `--force` in `apply` and `import`
- Adds `-o` alias for `--output` in `plan`, `apply`, and `diff`
- Adds `-w` alias for `--wide` in `plan`, `apply`, and `diff`
- Adds `-a` alias for `--all` in `import`
- Updates Commands Reference wiki with all short aliases

Closes #41

## Test plan

- [ ] `dns-sync plan -o json` works
- [ ] `dns-sync plan -w` works
- [ ] `dns-sync apply -f` overrides max-changes
- [ ] `dns-sync apply -y` (already existed, verify still works)
- [ ] `dns-sync import -p provider -a` works
- [ ] `dns-sync diff -w -o json` works