### PR TITLE
feat: --output color|plain|diff|json, remove --no-color (closes #49)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
       shell: bash
       run: |
         set +e
-        dns-sync plan -c "${{ inputs.config }}" --save-plan plan.yaml --exit-code -w --no-color 2>&1 | tee plan.txt
+        dns-sync plan -c "${{ inputs.config }}" --save-plan plan.yaml --exit-code -w --output diff 2>&1 | tee plan.txt
         echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
         set -e
 
@@ -84,7 +84,7 @@ runs:
             '<details>',
             '<summary>Full plan output</summary>',
             '',
-            '```',
+            '```diff',
             planText,
             '```',
             '',
@@ -135,10 +135,10 @@ runs:
       shell: bash
       run: |
         if [ -f plan.yaml ]; then
-          dns-sync apply -c "${{ inputs.config }}" --from-plan plan.yaml --yes --no-color
+          dns-sync apply -c "${{ inputs.config }}" --from-plan plan.yaml --yes --output plain
         else
           echo "No saved plan found for ${{ github.sha }} — running apply directly"
-          dns-sync apply -c "${{ inputs.config }}" --yes --no-color
+          dns-sync apply -c "${{ inputs.config }}" --yes --output plain
         fi
 
     - name: Post apply confirmation

--- a/src/DnsSync/Commands/ApplyCommand.cs
+++ b/src/DnsSync/Commands/ApplyCommand.cs
@@ -19,6 +19,10 @@ public class ApplyCommand(ILoggerFactory loggerFactory) : AsyncCommand<ApplySett
                 return 1;
             }
 
+            var output = settings.Output.ToLowerInvariant();
+            if (output is not ("color" or "plain" or "diff" or "json"))
+                throw new InvalidOperationException($"Unknown --output value '{settings.Output}'. Valid values: color, plain, diff, json.");
+
             var config = CommandHelpers.LoadAndValidateConfig(settings);
 
             if (settings.FromPlan is not null)
@@ -106,7 +110,7 @@ public class ApplyCommand(ILoggerFactory loggerFactory) : AsyncCommand<ApplySett
 
             // Print all plans
             foreach (var (zoneName, targetName, plan, _) in plans)
-                CommandHelpers.PrintPlan(plan, zoneName, targetName, settings.Wide);
+                CommandHelpers.PrintPlan(plan, zoneName, targetName, settings.Wide, output);
 
             // Safety guard: abort if too many changes
             if (!settings.Force && totalChanges > settings.MaxChanges)

--- a/src/DnsSync/Commands/BaseSettings.cs
+++ b/src/DnsSync/Commands/BaseSettings.cs
@@ -18,10 +18,6 @@ public class BaseSettings : CommandSettings
     [Description("Enable debug log output")]
     public bool Verbose { get; set; }
 
-    [CommandOption("--no-color")]
-    [Description("Disable ANSI colors in output (also respected via NO_COLOR env var)")]
-    public bool NoColor { get; set; }
-
     [CommandOption("--gcp-logs")]
     [Description("Output structured JSON logs for Google Cloud Logging (auto-enabled in Cloud Run)")]
     public bool GcpLogs { get; set; }

--- a/src/DnsSync/Commands/CommandHelpers.cs
+++ b/src/DnsSync/Commands/CommandHelpers.cs
@@ -58,8 +58,21 @@ public static class CommandHelpers
         }
     }
 
-    public static void PrintPlan(DnsPlan plan, string zoneName, string targetName, bool wide = false)
+    public static void PrintPlan(DnsPlan plan, string zoneName, string targetName, bool wide = false, string output = "color")
     {
+        if (string.Equals(output, "diff", StringComparison.OrdinalIgnoreCase))
+        {
+            PrintPlanDiff(plan, zoneName, targetName, wide);
+            return;
+        }
+
+        if (string.Equals(output, "plain", StringComparison.OrdinalIgnoreCase))
+        {
+            PrintPlanPlain(plan, zoneName, targetName, wide);
+            return;
+        }
+
+        // color (default)
         AnsiConsole.MarkupLine($"\nZone: [bold]{Markup.Escape(zoneName)}[/] → [bold]{Markup.Escape(targetName)}[/]");
 
         if (plan.IsEmpty)
@@ -124,6 +137,119 @@ public static class CommandHelpers
         if (plan.Deletes > 0) summary.Add($"[red]{plan.Deletes} delete(s)[/]");
 
         AnsiConsole.MarkupLine($"\n  {string.Join(", ", summary)}");
+    }
+
+    private static void PrintPlanPlain(DnsPlan plan, string zoneName, string targetName, bool wide)
+    {
+        Console.WriteLine($"\nZone: {zoneName} → {targetName}");
+
+        if (plan.IsEmpty)
+        {
+            Console.WriteLine("  No changes");
+            return;
+        }
+
+        foreach (var change in plan.Changes)
+        {
+            switch (change.ChangeType)
+            {
+                case ChangeType.Create:
+                    Console.WriteLine($"  + {change.RecordName,-45} {change.RecordType,-6} {change.After!.Ttl,5}" +
+                        (wide ? "" : $"  {Truncate(change.After.FormatValues())}"));
+                    if (wide)
+                        Console.WriteLine($"      {change.After.FormatValues()}");
+                    break;
+
+                case ChangeType.Update when change.IsTtlOnlyChange:
+                    Console.WriteLine($"  ~ {change.RecordName,-45} {change.RecordType,-6} {change.Before!.Ttl}→{change.After!.Ttl}" +
+                        (wide ? "  (ttl only)" : $"  {Truncate(change.After.FormatValues())}  (ttl only)"));
+                    if (wide)
+                        Console.WriteLine($"      {change.After!.FormatValues()}");
+                    break;
+
+                case ChangeType.Update:
+                    Console.WriteLine($"  ~ {change.RecordName,-45} {change.RecordType,-6} {change.After!.Ttl,5}");
+                    if (wide)
+                    {
+                        Console.WriteLine($"      before: {change.Before!.FormatValues()}");
+                        Console.WriteLine($"      after:  {change.After.FormatValues()}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"    before: {Truncate(change.Before!.FormatValues(), 120)}");
+                        Console.WriteLine($"    after:  {Truncate(change.After.FormatValues(), 120)}");
+                    }
+                    break;
+
+                case ChangeType.Delete:
+                    Console.WriteLine($"  - {change.RecordName,-45} {change.RecordType,-6} {change.Before!.Ttl,5}" +
+                        (wide ? "" : $"  {Truncate(change.Before.FormatValues())}"));
+                    if (wide)
+                        Console.WriteLine($"      {change.Before.FormatValues()}");
+                    break;
+            }
+        }
+
+        var summary = new List<string>();
+        if (plan.Creates > 0) summary.Add($"{plan.Creates} create(s)");
+        if (plan.Updates > 0) summary.Add($"{plan.Updates} update(s)");
+        if (plan.Deletes > 0) summary.Add($"{plan.Deletes} delete(s)");
+        Console.WriteLine($"\n  {string.Join(", ", summary)}");
+    }
+
+    private static void PrintPlanDiff(DnsPlan plan, string zoneName, string targetName, bool wide)
+    {
+        Console.WriteLine($"\n# Zone: {zoneName} → {targetName}");
+
+        if (plan.IsEmpty)
+        {
+            Console.WriteLine("# No changes");
+            return;
+        }
+
+        foreach (var change in plan.Changes)
+        {
+            switch (change.ChangeType)
+            {
+                case ChangeType.Create:
+                    Console.WriteLine($"+ {change.RecordName,-45} {change.RecordType,-6} {change.After!.Ttl,5}" +
+                        (wide ? "" : $"  {Truncate(change.After.FormatValues())}"));
+                    if (wide)
+                        Console.WriteLine($"+   {change.After.FormatValues()}");
+                    break;
+
+                case ChangeType.Update when change.IsTtlOnlyChange:
+                    Console.WriteLine($"- {change.RecordName,-45} {change.RecordType,-6} {change.Before!.Ttl,5}  (ttl only)");
+                    Console.WriteLine($"+ {change.RecordName,-45} {change.RecordType,-6} {change.After!.Ttl,5}  (ttl only)");
+                    break;
+
+                case ChangeType.Update:
+                    Console.WriteLine($"- {change.RecordName,-45} {change.RecordType,-6} {change.Before!.Ttl,5}");
+                    if (wide)
+                        Console.WriteLine($"-   {change.Before.FormatValues()}");
+                    else
+                        Console.WriteLine($"-   {Truncate(change.Before.FormatValues(), 120)}");
+                    Console.WriteLine($"+ {change.RecordName,-45} {change.RecordType,-6} {change.After!.Ttl,5}");
+                    if (wide)
+                        Console.WriteLine($"+   {change.After.FormatValues()}");
+                    else
+                        Console.WriteLine($"+   {Truncate(change.After.FormatValues(), 120)}");
+                    break;
+
+                case ChangeType.Delete:
+                    Console.WriteLine($"- {change.RecordName,-45} {change.RecordType,-6} {change.Before!.Ttl,5}" +
+                        (wide ? "" : $"  {Truncate(change.Before.FormatValues())}"));
+                    if (wide)
+                        Console.WriteLine($"-   {change.Before.FormatValues()}");
+                    break;
+            }
+        }
+
+        var parts = new List<string>();
+        if (plan.Creates > 0) parts.Add($"{plan.Creates} create(s)");
+        if (plan.Updates > 0) parts.Add($"{plan.Updates} update(s)");
+        if (plan.Deletes > 0) parts.Add($"{plan.Deletes} delete(s)");
+        Console.WriteLine($"\n# {string.Join(", ", parts)}");
     }
 
     public static void PrintError(Exception ex, bool verbose = false)

--- a/src/DnsSync/Commands/DiffCommand.cs
+++ b/src/DnsSync/Commands/DiffCommand.cs
@@ -11,7 +11,10 @@ public class DiffCommand(ILoggerFactory loggerFactory) : AsyncCommand<DiffSettin
 {
     protected override async Task<int> ExecuteAsync(CommandContext context, DiffSettings settings, CancellationToken cancellationToken)
     {
-        var jsonMode = string.Equals(settings.Output, "json", StringComparison.OrdinalIgnoreCase);
+        var output = settings.Output.ToLowerInvariant();
+        if (output is not ("color" or "plain" or "diff" or "json"))
+            throw new InvalidOperationException($"Unknown --output value '{settings.Output}'. Valid values: color, plain, diff, json.");
+        var jsonMode = output == "json";
         var useSpinners = !jsonMode && !settings.GcpLogs && !settings.Verbose;
 
         try
@@ -134,7 +137,7 @@ public class DiffCommand(ILoggerFactory loggerFactory) : AsyncCommand<DiffSettin
                     if (jsonMode)
                         jsonZones.Add(BuildJsonDiff(zoneName, settings.From, settings.To, plan));
                     else
-                        CommandHelpers.PrintPlan(plan, zoneName, settings.To, settings.Wide);
+                        CommandHelpers.PrintPlan(plan, zoneName, settings.To, settings.Wide, output);
 
                     totalChanges += plan.Total;
                 }

--- a/src/DnsSync/Commands/DiffSettings.cs
+++ b/src/DnsSync/Commands/DiffSettings.cs
@@ -26,9 +26,9 @@ public class DiffSettings : BaseSettings
     public bool Wide { get; set; }
 
     [CommandOption("-o|--output <FORMAT>")]
-    [Description("Output format: text (default) or json")]
-    [DefaultValue("text")]
-    public string Output { get; set; } = "text";
+    [Description("Output format: color (default), plain, diff, or json")]
+    [DefaultValue("color")]
+    public string Output { get; set; } = "color";
 
     [CommandOption("--exit-code")]
     [Description("Return exit code 2 when there are differences (Terraform-compatible)")]

--- a/src/DnsSync/Commands/PlanCommand.cs
+++ b/src/DnsSync/Commands/PlanCommand.cs
@@ -12,7 +12,10 @@ public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettin
 {
     protected override async Task<int> ExecuteAsync(CommandContext context, PlanSettings settings, CancellationToken cancellationToken)
     {
-        var jsonMode = string.Equals(settings.Output, "json", StringComparison.OrdinalIgnoreCase);
+        var output = settings.Output.ToLowerInvariant();
+        if (output is not ("color" or "plain" or "diff" or "json"))
+            throw new InvalidOperationException($"Unknown --output value '{settings.Output}'. Valid values: color, plain, diff, json.");
+        var jsonMode = output == "json";
         var useSpinners = !jsonMode && !settings.GcpLogs && !settings.Verbose;
 
         try
@@ -105,7 +108,7 @@ public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettin
                         }
                         else
                         {
-                            CommandHelpers.PrintPlan(plan, zoneName, targetName, settings.Wide);
+                            CommandHelpers.PrintPlan(plan, zoneName, targetName, settings.Wide, output);
                         }
 
                         savedZonePlans.Add((zoneName, targetName, plan));

--- a/src/DnsSync/Commands/PlanSettings.cs
+++ b/src/DnsSync/Commands/PlanSettings.cs
@@ -18,9 +18,9 @@ public class PlanSettings : BaseSettings
     public bool ExitCode { get; set; }
 
     [CommandOption("-o|--output <FORMAT>")]
-    [Description("Output format: text (default) or json")]
-    [DefaultValue("text")]
-    public string Output { get; set; } = "text";
+    [Description("Output format: color (default), plain, diff, or json")]
+    [DefaultValue("color")]
+    public string Output { get; set; } = "color";
 
     [CommandOption("--save-plan <PATH>")]
     [Description("Save the computed plan to a signed YAML file for later use with 'apply --from-plan'")]

--- a/src/DnsSync/Program.cs
+++ b/src/DnsSync/Program.cs
@@ -42,8 +42,9 @@ else
 var verbose = args.Contains("--verbose") || args.Contains("-v");
 var serilogLevel = verbose ? LogEventLevel.Debug : LogEventLevel.Information;
 
-// Disable ANSI colors if --no-color flag or NO_COLOR env var is set (https://no-color.org/)
-var noColor = args.Contains("--no-color")
+// Disable ANSI colors if --output plain/diff or NO_COLOR env var is set (https://no-color.org/)
+var outputArg = args.SkipWhile(a => a != "--output" && a != "-o").Skip(1).FirstOrDefault() ?? "color";
+var noColor = outputArg is "plain" or "diff"
     || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR"));
 
 if (noColor)


### PR DESCRIPTION
## Summary

Extends `--output` (on `plan`, `apply`, `diff`) from `text|json` to `color|plain|diff|json`:

| Value | Description |
|-------|-------------|
| `color` | ANSI colors — new default (replaces `text`) |
| `plain` | No color codes — replaces `--no-color` |
| `diff` | GitHub diff syntax: `+` creates, `-` deletes — renders green/red in PR comments |
| `json` | Structured JSON — unchanged |

- Removes `--no-color` from global options (`BaseSettings`, `Program.cs`)
- Updates `action.yml`: plan step uses `--output diff`, apply step uses `--output plain`
- PR comment block changed from ` ```  ``` ` to ` ```diff ``` ` for native GitHub color highlighting

Closes #49

## Test plan

- [ ] `dns-sync plan -c config.yaml` — color output unchanged
- [ ] `dns-sync plan -c config.yaml --output plain` — no ANSI codes
- [ ] `dns-sync plan -c config.yaml --output diff` — lines prefixed with `+`/`-`, no ANSI
- [ ] `dns-sync plan -c config.yaml --output json` — JSON output unchanged
- [ ] `dns-sync plan -c config.yaml --output text` — fails with clear error
- [ ] GitHub Actions PR comment shows green/red diff highlighting