### PR TITLE
feat: import enhancements (provider header + auto config update)

### DIFF
--- a/src/DnsSync/Commands/ImportCommand.cs
+++ b/src/DnsSync/Commands/ImportCommand.cs
@@ -62,6 +62,7 @@ public class ImportCommand(ILoggerFactory loggerFactory) : AsyncCommand<ImportSe
 
             var imported = 0;
             var skipped = 0;
+            var importedZones = new List<string>();
 
             foreach (var zoneName in zones)
             {
@@ -83,13 +84,49 @@ public class ImportCommand(ILoggerFactory loggerFactory) : AsyncCommand<ImportSe
                         return await provider.GetZoneAsync(zoneName, cancellationToken);
                     });
 
-                var yaml = ZoneYamlSerializer.Serialize(zone);
+                var yaml = ZoneYamlSerializer.Serialize(zone, settings.Provider);
                 await File.WriteAllTextAsync(outputPath, yaml, cancellationToken);
 
                 AnsiConsole.MarkupLine(
                     $"  [green]+[/] {Markup.Escape(zoneName)} → [dim]{Markup.Escape(outputPath)}[/] " +
                     $"([bold]{zone.Records.Count}[/] record(s))");
                 imported++;
+                importedZones.Add(zoneName);
+            }
+
+            if (!settings.NoConfigUpdate && importedZones.Count > 0)
+            {
+                var configPath = Path.GetFullPath(settings.ConfigPath);
+                var configText = await File.ReadAllTextAsync(configPath, cancellationToken);
+                var added = 0;
+                var alreadyInConfig = 0;
+                var appendBuilder = new System.Text.StringBuilder();
+
+                foreach (var zoneName in importedZones)
+                {
+                    if (config.Zones.ContainsKey(zoneName))
+                    {
+                        alreadyInConfig++;
+                        continue;
+                    }
+
+                    appendBuilder.AppendLine($"  {zoneName}:");
+                    appendBuilder.AppendLine($"    source: {settings.Provider}");
+                    appendBuilder.AppendLine($"    targets: []");
+                    added++;
+                }
+
+                if (added > 0)
+                {
+                    configText = configText.TrimEnd() + "\n" + appendBuilder.ToString().TrimEnd() + "\n";
+                    await File.WriteAllTextAsync(configPath, configText, cancellationToken);
+                }
+
+                AnsiConsole.WriteLine();
+                if (added > 0)
+                    AnsiConsole.MarkupLine($"[green]✓[/] Added [bold]{added}[/] zone(s) to config");
+                if (alreadyInConfig > 0)
+                    AnsiConsole.MarkupLine($"[yellow]~[/] Skipped [bold]{alreadyInConfig}[/] zone(s) (already in config)");
             }
 
             AnsiConsole.WriteLine();

--- a/src/DnsSync/Commands/ImportSettings.cs
+++ b/src/DnsSync/Commands/ImportSettings.cs
@@ -25,4 +25,8 @@ public class ImportSettings : BaseSettings
     [CommandOption("-f|--force")]
     [Description("Overwrite existing zone files")]
     public bool Force { get; set; }
+
+    [CommandOption("--no-config-update")]
+    [Description("Skip updating the config file with imported zones")]
+    public bool NoConfigUpdate { get; set; }
 }

--- a/src/DnsSync/Providers/Yaml/ZoneYamlSerializer.cs
+++ b/src/DnsSync/Providers/Yaml/ZoneYamlSerializer.cs
@@ -10,11 +10,12 @@ namespace DnsSync.Providers.Yaml;
 /// </summary>
 public static class ZoneYamlSerializer
 {
-    public static string Serialize(DnsZone zone)
+    public static string Serialize(DnsZone zone, string? providerName = null)
     {
         var sb = new StringBuilder();
         sb.AppendLine($"# Zone: {zone.Name}");
-        sb.AppendLine($"# Imported by dns-sync on {DateTime.UtcNow:yyyy-MM-dd}");
+        var fromClause = providerName is not null ? $"from {providerName} " : "";
+        sb.AppendLine($"# Imported {fromClause}by dns-sync on {DateTime.UtcNow:yyyy-MM-dd}");
         sb.AppendLine();
 
         // Group records by subdomain key for output


### PR DESCRIPTION
## Summary

Closes #46

- **Provider name in file header**: Imported zone files now include the source provider in the comment header (`# Imported from cloudflare by dns-sync on 2026-04-29`).
- **Auto config update**: After importing, zones are automatically appended to `config.yaml` with `source` set to the provider and `targets: []`. Zones already present in the config are skipped.
- **`--no-config-update` flag**: Opt-out flag to skip the config file update when not needed.

## Test plan

- [x] `dns-sync import -c config.yaml -p <provider> -z example.com.` → header includes `from <provider>`
- [ ] `dns-sync import -c config.yaml -p <provider> --all` → zones appended to config, summary shows added/skipped counts
- [x] Re-run same command → skips zones already in config (idempotent)
- [ ] `dns-sync import ... --no-config-update` → config file unchanged
- [ ] `dns-sync validate -c config.yaml` → config remains valid after update