### PR TITLE
feat: add dns-sync drift command for automated drift detection

### DIFF
--- a/src/DnsSync/Commands/DriftCommand.cs
+++ b/src/DnsSync/Commands/DriftCommand.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using DnsSync.Core;
+using DnsSync.Providers;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace DnsSync.Commands;
+
+public class DriftCommand(ILoggerFactory loggerFactory) : AsyncCommand<DriftSettings>
+{
+    protected override async Task<int> ExecuteAsync(
+        CommandContext context, DriftSettings settings, CancellationToken cancellationToken)
+    {
+        var output = settings.Output.ToLowerInvariant();
+        if (output is not ("color" or "plain" or "json" or "silent"))
+            throw new InvalidOperationException(
+                $"Unknown --output value '{settings.Output}'. Valid values: color, plain, json, silent.");
+
+        var jsonMode = output == "json";
+        var silent = output == "silent";
+        var useSpinners = !jsonMode && !silent && !settings.GcpLogs && !settings.Verbose;
+
+        try
+        {
+            var config = CommandHelpers.LoadAndValidateConfig(settings);
+
+            var driftDetected = false;
+            var hasErrors = false;
+            var jsonZones = new List<object>();
+
+            foreach (var (zoneName, zoneConfig) in config.Zones)
+            {
+                var sourceProvider = ProviderFactory.Create(
+                    zoneConfig.Source, config.Providers[zoneConfig.Source], loggerFactory);
+
+                DnsZone sourceZone;
+                if (useSpinners)
+                {
+                    sourceZone = await AnsiConsole.Status().StartAsync(
+                        $"Fetching {zoneName} from '{zoneConfig.Source}'...",
+                        async ctx =>
+                        {
+                            ctx.Spinner(Spinner.Known.Dots);
+                            await sourceProvider.PreflightAsync(cancellationToken);
+                            return await sourceProvider.GetZoneAsync(zoneName, cancellationToken);
+                        });
+                }
+                else
+                {
+                    await sourceProvider.PreflightAsync(cancellationToken);
+                    sourceZone = await sourceProvider.GetZoneAsync(zoneName, cancellationToken);
+                }
+
+                foreach (var targetName in zoneConfig.Targets)
+                {
+                    var targetProvider = ProviderFactory.Create(
+                        targetName, config.Providers[targetName], loggerFactory);
+
+                    try
+                    {
+                        DnsZone targetZone;
+                        if (useSpinners)
+                        {
+                            targetZone = await AnsiConsole.Status().StartAsync(
+                                $"Checking {zoneName} against '{targetName}'...",
+                                async ctx =>
+                                {
+                                    ctx.Spinner(Spinner.Known.Dots);
+                                    await targetProvider.PreflightAsync(cancellationToken);
+                                    return await targetProvider.GetZoneAsync(zoneName, cancellationToken);
+                                });
+                        }
+                        else
+                        {
+                            await targetProvider.PreflightAsync(cancellationToken);
+                            targetZone = await targetProvider.GetZoneAsync(zoneName, cancellationToken);
+                        }
+
+                        var plan = ZoneDiff.Diff(sourceZone, targetZone, settings.IncludeApexNs);
+
+                        var changes = settings.IgnoreTtl
+                            ? plan.Changes.Where(c => !c.IsTtlOnlyChange).ToList()
+                            : plan.Changes.ToList();
+
+                        var hasDrift = changes.Count > 0;
+                        if (hasDrift) driftDetected = true;
+
+                        if (jsonMode)
+                        {
+                            jsonZones.Add(BuildJsonResult(zoneName, targetName, changes));
+                        }
+                        else if (!silent)
+                        {
+                            if (hasDrift)
+                                AnsiConsole.MarkupLine(
+                                    $"  [red]✗[/] {Markup.Escape(zoneName)} → {Markup.Escape(targetName)}" +
+                                    $" — [bold]{changes.Count}[/] change(s) " +
+                                    $"(+{changes.Count(c => c.ChangeType == ChangeType.Create)} " +
+                                    $"~{changes.Count(c => c.ChangeType == ChangeType.Update)} " +
+                                    $"-{changes.Count(c => c.ChangeType == ChangeType.Delete)})");
+                            else
+                                AnsiConsole.MarkupLine(
+                                    $"  [green]✓[/] {Markup.Escape(zoneName)} → {Markup.Escape(targetName)} — in sync");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!jsonMode && !silent)
+                            AnsiConsole.MarkupLine(
+                                $"  [red]✗[/] {Markup.Escape(zoneName)} → {Markup.Escape(targetName)}: {Markup.Escape(ex.Message)}");
+                        hasErrors = true;
+                    }
+                }
+            }
+
+            if (jsonMode)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(jsonZones,
+                    new JsonSerializerOptions { WriteIndented = true }));
+            }
+            else if (!silent)
+            {
+                AnsiConsole.WriteLine();
+                if (driftDetected)
+                    AnsiConsole.MarkupLine("[red]✗ Drift detected.[/] Run [bold]dns-sync plan[/] to review changes.");
+                else if (!hasErrors)
+                    AnsiConsole.MarkupLine("[green]✓ All zones are in sync.[/]");
+            }
+
+            return hasErrors || driftDetected ? 1 : 0;
+        }
+        catch (Exception ex)
+        {
+            CommandHelpers.PrintError(ex, settings.Verbose);
+            return 1;
+        }
+    }
+
+    private static object BuildJsonResult(string zoneName, string targetName, IReadOnlyList<Core.RecordChange> changes) =>
+        new
+        {
+            zone = zoneName,
+            target = targetName,
+            drift = changes.Count > 0,
+            creates = changes.Count(c => c.ChangeType == ChangeType.Create),
+            updates = changes.Count(c => c.ChangeType == ChangeType.Update),
+            deletes = changes.Count(c => c.ChangeType == ChangeType.Delete),
+        };
+}

--- a/src/DnsSync/Commands/DriftSettings.cs
+++ b/src/DnsSync/Commands/DriftSettings.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace DnsSync.Commands;
+
+public class DriftSettings : BaseSettings
+{
+    [CommandOption("--include-apex-ns")]
+    [Description("Include apex NS records in the diff (excluded by default to prevent registrar conflicts)")]
+    public bool IncludeApexNs { get; set; }
+
+    [CommandOption("--ignore-ttl")]
+    [Description("Ignore TTL-only differences when detecting drift")]
+    public bool IgnoreTtl { get; set; }
+
+    [CommandOption("-o|--output <FORMAT>")]
+    [Description("Output format: color (default), plain, json, or silent")]
+    [DefaultValue("color")]
+    public string Output { get; set; } = "color";
+}

--- a/src/DnsSync/Program.cs
+++ b/src/DnsSync/Program.cs
@@ -148,6 +148,11 @@ app.Configure(config =>
         .WithDescription("Compare DNS state between two providers directly (read-only)")
         .WithExample(["diff", "--from", "cloudflare", "--to", "route53", "--config", "config.yaml"])
         .WithExample(["diff", "--from", "cloudflare", "--to", "porkbun", "--zone", "example.com.", "--config", "config.yaml"]);
+
+    config.AddCommand<DriftCommand>("drift")
+        .WithDescription("Detect DNS record drift from desired state without applying changes")
+        .WithExample(["drift", "--config", "config.yaml"])
+        .WithExample(["drift", "--config", "config.yaml", "--output", "json"]);
 });
 
 return await app.RunAsync(args);


### PR DESCRIPTION
## Summary

Closes #15

Adds a new `drift` command for automated, machine-friendly drift detection — distinct from `plan` which is designed for human review.

- **Exit 0**: all zones in sync
- **Exit 1**: drift detected or error
- `--ignore-ttl`: skip TTL-only differences
- `--include-apex-ns`: include apex NS records in the diff
- `--output json`: structured output with per-zone drift counts
- `--output silent`: no stdout, only the exit code (ideal for cron)

## Example usage

```bash
# Scheduled check (cron/CI)
dns-sync drift -c config.yaml

# Ignore TTL-only changes
dns-sync drift -c config.yaml --ignore-ttl

# JSON output for downstream processing
dns-sync drift -c config.yaml --output json

# Silent — only exit code matters
dns-sync drift -c config.yaml --output silent
```

## Test plan

- [ ] `dns-sync drift -c config.yaml` → exit 0 when in sync, 1 when drift detected
- [ ] `--ignore-ttl` → TTL-only changes do not trigger exit 1
- [ ] `--output json` → valid JSON with `drift`, `creates`, `updates`, `deletes` fields per zone/target
- [ ] `--output silent` → no stdout output
- [ ] `dotnet test` passes (188 tests)