### PR TITLE
fix: quote special characters in YAML serializer string values

### DIFF
--- a/src/DnsSync/Providers/Yaml/ZoneYamlSerializer.cs
+++ b/src/DnsSync/Providers/Yaml/ZoneYamlSerializer.cs
@@ -116,13 +116,25 @@ public static class ZoneYamlSerializer
     {
         if (values.Count == 1)
         {
-            sb.AppendLine($"{indent}value: {values[0]}");
+            sb.AppendLine($"{indent}value: {QuoteScalar(values[0])}");
             return;
         }
 
         sb.AppendLine($"{indent}values:");
         foreach (var v in values)
-            sb.AppendLine($"{indent}  - {v}");
+            sb.AppendLine($"{indent}  - {QuoteScalar(v)}");
+    }
+
+    // Quote a plain scalar if it contains characters that YAML reserves at the start of a token
+    // or that would be ambiguous mid-value (@, `, and strings with spaces or YAML special chars).
+    private static string QuoteScalar(string value)
+    {
+        if (value.Length == 0) return "\"\"";
+        var first = value[0];
+        if (first == '@' || first == '`' || value.Contains(' ') || value.Contains(':') ||
+            value.Contains('#') || value.Contains('"') || value.Contains('\\'))
+            return $"\"{value.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"";
+        return value;
     }
 
     private static void AppendQuotedStringList(StringBuilder sb, IReadOnlyList<string> values, string indent)


### PR DESCRIPTION
## Summary

Fixes #57

`AppendStringList` (used for A, AAAA, and NS records) was writing values as plain YAML scalars without quoting. This caused parse errors when reading back zone files if the provider returned values starting with YAML-reserved characters (`@`, `` ` ``) or containing spaces, colons, or other special characters.

**Repro:** Importing from GoDaddy produces a CNAME with `value: @.` — the `@` character cannot start a plain YAML scalar, causing:
```
✗ While scanning for the next token, found character that cannot start any token.
```

## Fix

Adds `QuoteScalar()` helper (parallel to existing `QuoteTxt()` for TXT records) that wraps values in double quotes when needed. Applied to all `AppendStringList` call sites.

## Test plan

- [ ] Import a zone containing `@.` CNAME or A records with spaces → serialized file parses correctly
- [ ] `dns-sync validate` on existing zone files passes
- [ ] `dotnet test` passes (188 tests)