### PR TITLE
feat: add --zone|-z flag to plan and apply for single-zone targeting

### DIFF
--- a/src/DnsSync/Commands/ApplyCommand.cs
+++ b/src/DnsSync/Commands/ApplyCommand.cs
@@ -28,6 +28,16 @@ public class ApplyCommand(ILoggerFactory loggerFactory) : AsyncCommand<ApplySett
             if (settings.FromPlan is not null)
                 return await ApplyFromPlanAsync(settings, config, cancellationToken);
 
+            var zonesToProcess = config.Zones.AsEnumerable();
+            if (!string.IsNullOrWhiteSpace(settings.Zone))
+            {
+                if (!config.Zones.ContainsKey(settings.Zone))
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Zone '{Markup.Escape(settings.Zone)}' not found in config.");
+                    return 1;
+                }
+                zonesToProcess = zonesToProcess.Where(z => z.Key == settings.Zone);
+            }
 
             var useSpinners = !settings.GcpLogs && !settings.Verbose;
 
@@ -37,7 +47,7 @@ public class ApplyCommand(ILoggerFactory loggerFactory) : AsyncCommand<ApplySett
             var plans = new List<(string ZoneName, string TargetName, DnsPlan Plan, IProvider Provider)>();
             var hasErrors = false;
 
-            foreach (var (zoneName, zoneConfig) in config.Zones)
+            foreach (var (zoneName, zoneConfig) in zonesToProcess)
             {
                 var sourceProvider = ProviderFactory.Create(
                     zoneConfig.Source, config.Providers[zoneConfig.Source], loggerFactory);

--- a/src/DnsSync/Commands/PlanCommand.cs
+++ b/src/DnsSync/Commands/PlanCommand.cs
@@ -22,6 +22,17 @@ public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettin
         {
             var config = CommandHelpers.LoadAndValidateConfig(settings);
 
+            var zonesToProcess = config.Zones.AsEnumerable();
+            if (!string.IsNullOrWhiteSpace(settings.Zone))
+            {
+                if (!config.Zones.ContainsKey(settings.Zone))
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] Zone '{Markup.Escape(settings.Zone)}' not found in config.");
+                    return 1;
+                }
+                zonesToProcess = zonesToProcess.Where(z => z.Key == settings.Zone);
+            }
+
             if (!jsonMode)
                 AnsiConsole.MarkupLine("\nRunning pre-flight checks...");
 
@@ -34,7 +45,7 @@ public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettin
             // Accumulator for --save-plan
             var savedZonePlans = new List<(string ZoneName, string TargetName, DnsPlan Plan)>();
 
-            foreach (var (zoneName, zoneConfig) in config.Zones)
+            foreach (var (zoneName, zoneConfig) in zonesToProcess)
             {
                 var sourceProvider = ProviderFactory.Create(
                     zoneConfig.Source, config.Providers[zoneConfig.Source], loggerFactory);

--- a/src/DnsSync/Commands/PlanSettings.cs
+++ b/src/DnsSync/Commands/PlanSettings.cs
@@ -25,4 +25,8 @@ public class PlanSettings : BaseSettings
     [CommandOption("--save-plan <PATH>")]
     [Description("Save the computed plan to a signed YAML file for later use with 'apply --from-plan'")]
     public string? SavePlan { get; set; }
+
+    [CommandOption("-z|--zone <ZONE>")]
+    [Description("Only process a single zone (e.g. example.com.) — skips preflight for all other providers")]
+    public string? Zone { get; set; }
 }


### PR DESCRIPTION
## Summary

Closes #58

Adds `-z|--zone <ZONE>` to both `plan` and `apply` (via `PlanSettings`, which `ApplySettings` inherits). When provided, only the specified zone is processed and only its source/target providers run preflight checks — all other zones and providers are skipped.

## Usage

```bash
# Plan only one zone
dns-sync plan -c config.yaml --zone example.com.

# Apply only one zone without confirmation
dns-sync apply -c config.yaml --zone example.com. --yes

# Zone not in config → clear error, exit 1
dns-sync plan -c config.yaml --zone unknown.com.
# ✗ Zone 'unknown.com.' not found in config.
```

## Test plan

- [ ] `plan --zone example.com.` → only that zone is planned, preflight skips other providers
- [x] `apply --zone example.com. --yes` → only that zone is applied
- [x] `plan --zone nonexistent.com.` → exit 1 with error message
- [x] `plan` without `--zone` → all zones processed as before (no regression)
- [x] `dotnet test` passes (188 tests)