### PR TITLE
feat: zone_groups support and ZoneResolver service

### DIFF
--- a/src/DnsSync/Commands/ApplyCommand.cs
+++ b/src/DnsSync/Commands/ApplyCommand.cs
@@ -7,7 +7,7 @@ using Spectre.Console.Cli;
 
 namespace DnsSync.Commands;
 
-public class ApplyCommand(ILoggerFactory loggerFactory) : AsyncCommand<ApplySettings>
+public class ApplyCommand(ILoggerFactory loggerFactory, IZoneResolver zoneResolver) : AsyncCommand<ApplySettings>
 {
     protected override async Task<int> ExecuteAsync(CommandContext context, ApplySettings settings, CancellationToken cancellationToken)
     {
@@ -28,10 +28,12 @@ public class ApplyCommand(ILoggerFactory loggerFactory) : AsyncCommand<ApplySett
             if (settings.FromPlan is not null)
                 return await ApplyFromPlanAsync(settings, config, cancellationToken);
 
-            var zonesToProcess = config.Zones.AsEnumerable();
+            var allZones = await zoneResolver.ResolveAsync(config, cancellationToken);
+
+            var zonesToProcess = allZones.AsEnumerable();
             if (!string.IsNullOrWhiteSpace(settings.Zone))
             {
-                if (!config.Zones.ContainsKey(settings.Zone))
+                if (!allZones.ContainsKey(settings.Zone))
                 {
                     AnsiConsole.MarkupLine($"[red]✗[/] Zone '{Markup.Escape(settings.Zone)}' not found in config.");
                     return 1;

--- a/src/DnsSync/Commands/CommandHelpers.cs
+++ b/src/DnsSync/Commands/CommandHelpers.cs
@@ -33,9 +33,11 @@ public static class CommandHelpers
         }
 
         var zoneCount = config.Zones.Count;
+        var groupCount = config.ZoneGroups.Count;
         var providerCount = config.Providers.Count;
+        var groupPart = groupCount > 0 ? $", [bold]{groupCount}[/] zone group(s)" : "";
         AnsiConsole.MarkupLine(
-            $"[green]✓[/] Config valid ([bold]{zoneCount}[/] zone(s), [bold]{providerCount}[/] provider(s))");
+            $"[green]✓[/] Config valid ([bold]{zoneCount}[/] zone(s){groupPart}, [bold]{providerCount}[/] provider(s))");
 
         return config;
     }

--- a/src/DnsSync/Commands/DriftCommand.cs
+++ b/src/DnsSync/Commands/DriftCommand.cs
@@ -7,7 +7,7 @@ using Spectre.Console.Cli;
 
 namespace DnsSync.Commands;
 
-public class DriftCommand(ILoggerFactory loggerFactory) : AsyncCommand<DriftSettings>
+public class DriftCommand(ILoggerFactory loggerFactory, IZoneResolver zoneResolver) : AsyncCommand<DriftSettings>
 {
     protected override async Task<int> ExecuteAsync(
         CommandContext context, DriftSettings settings, CancellationToken cancellationToken)
@@ -29,7 +29,8 @@ public class DriftCommand(ILoggerFactory loggerFactory) : AsyncCommand<DriftSett
             var hasErrors = false;
             var jsonZones = new List<object>();
 
-            foreach (var (zoneName, zoneConfig) in config.Zones)
+            var zones = await zoneResolver.ResolveAsync(config, cancellationToken);
+            foreach (var (zoneName, zoneConfig) in zones)
             {
                 var sourceProvider = ProviderFactory.Create(
                     zoneConfig.Source, config.Providers[zoneConfig.Source], loggerFactory);

--- a/src/DnsSync/Commands/PlanCommand.cs
+++ b/src/DnsSync/Commands/PlanCommand.cs
@@ -8,7 +8,7 @@ using Spectre.Console.Cli;
 
 namespace DnsSync.Commands;
 
-public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettings>
+public class PlanCommand(ILoggerFactory loggerFactory, IZoneResolver zoneResolver) : AsyncCommand<PlanSettings>
 {
     protected override async Task<int> ExecuteAsync(CommandContext context, PlanSettings settings, CancellationToken cancellationToken)
     {
@@ -22,10 +22,12 @@ public class PlanCommand(ILoggerFactory loggerFactory) : AsyncCommand<PlanSettin
         {
             var config = CommandHelpers.LoadAndValidateConfig(settings);
 
-            var zonesToProcess = config.Zones.AsEnumerable();
+            var allZones = await zoneResolver.ResolveAsync(config, cancellationToken);
+
+            var zonesToProcess = allZones.AsEnumerable();
             if (!string.IsNullOrWhiteSpace(settings.Zone))
             {
-                if (!config.Zones.ContainsKey(settings.Zone))
+                if (!allZones.ContainsKey(settings.Zone))
                 {
                     AnsiConsole.MarkupLine($"[red]✗[/] Zone '{Markup.Escape(settings.Zone)}' not found in config.");
                     return 1;

--- a/src/DnsSync/Commands/ValidateCommand.cs
+++ b/src/DnsSync/Commands/ValidateCommand.cs
@@ -1,3 +1,4 @@
+using DnsSync.Core;
 using DnsSync.Providers;
 using DnsSync.Providers.Yaml;
 using DnsSync.Validation;
@@ -6,7 +7,7 @@ using Spectre.Console.Cli;
 
 namespace DnsSync.Commands;
 
-public class ValidateCommand : AsyncCommand<BaseSettings>
+public class ValidateCommand(IZoneResolver zoneResolver) : AsyncCommand<BaseSettings>
 {
     protected override async Task<int> ExecuteAsync(CommandContext context, BaseSettings settings, CancellationToken cancellationToken)
     {
@@ -16,7 +17,8 @@ public class ValidateCommand : AsyncCommand<BaseSettings>
 
             // Validate each zone file via YamlProvider
             var hasErrors = false;
-            foreach (var (zoneName, zoneConfig) in config.Zones)
+            var zones = await zoneResolver.ResolveAsync(config, cancellationToken);
+            foreach (var (zoneName, zoneConfig) in zones)
             {
                 var sourceProvider = config.Providers[zoneConfig.Source];
                 if (!string.Equals(sourceProvider.Type, "yaml", StringComparison.OrdinalIgnoreCase))

--- a/src/DnsSync/Config/ConfigLoader.cs
+++ b/src/DnsSync/Config/ConfigLoader.cs
@@ -69,8 +69,8 @@ public static class ConfigLoader
         if (config.Providers.Count == 0)
             errors.Add("No providers defined in config.");
 
-        if (config.Zones.Count == 0)
-            errors.Add("No zones defined in config.");
+        if (config.Zones.Count == 0 && config.ZoneGroups.Count == 0)
+            errors.Add("No zones or zone_groups defined in config.");
 
         foreach (var (name, provider) in config.Providers)
         {
@@ -136,6 +136,29 @@ public static class ConfigLoader
 
                 if (config.Providers.TryGetValue(target, out var targetConfig) && targetConfig.ReadOnly)
                     errors.Add($"Zone '{zoneName}' uses read-only provider '{target}' as a target — remove 'readonly: true' or use a different target.");
+            }
+        }
+
+        foreach (var (groupName, group) in config.ZoneGroups)
+        {
+            if (string.IsNullOrWhiteSpace(group.Source))
+                errors.Add($"zone_groups.{groupName}: missing 'source'.");
+            else if (!config.Providers.ContainsKey(group.Source))
+                errors.Add($"zone_groups.{groupName}: source '{group.Source}' not found in providers.");
+
+            if (group.Targets.Count == 0)
+                errors.Add($"zone_groups.{groupName}: has no target providers.");
+
+            foreach (var target in group.Targets)
+            {
+                if (!config.Providers.ContainsKey(target))
+                    errors.Add($"zone_groups.{groupName}: target '{target}' not found in providers.");
+
+                if (target == group.Source)
+                    errors.Add($"zone_groups.{groupName}: uses '{target}' as both source and target.");
+
+                if (config.Providers.TryGetValue(target, out var targetConfig) && targetConfig.ReadOnly)
+                    errors.Add($"zone_groups.{groupName}: uses read-only provider '{target}' as a target.");
             }
         }
 

--- a/src/DnsSync/Config/DnsSyncConfig.cs
+++ b/src/DnsSync/Config/DnsSyncConfig.cs
@@ -9,6 +9,9 @@ public class DnsSyncConfig
 
     [YamlMember(Alias = "zones")]
     public Dictionary<string, ZoneConfig> Zones { get; set; } = new();
+
+    [YamlMember(Alias = "zone_groups")]
+    public Dictionary<string, ZoneGroupConfig> ZoneGroups { get; set; } = new();
 }
 
 public class ProviderConfig
@@ -72,4 +75,21 @@ public class ZoneConfig
 
     [YamlMember(Alias = "targets")]
     public List<string> Targets { get; set; } = new();
+}
+
+public class ZoneGroupConfig
+{
+    [YamlMember(Alias = "source")]
+    public string Source { get; set; } = string.Empty;
+
+    [YamlMember(Alias = "targets")]
+    public List<string> Targets { get; set; } = new();
+
+    /// <summary>Optional regex. Only zones whose FQDN matches are included.</summary>
+    [YamlMember(Alias = "include_pattern")]
+    public string? IncludePattern { get; set; }
+
+    /// <summary>Optional regex. Zones whose FQDN matches are excluded (applied after include_pattern).</summary>
+    [YamlMember(Alias = "exclude_pattern")]
+    public string? ExcludePattern { get; set; }
 }

--- a/src/DnsSync/Core/IZoneResolver.cs
+++ b/src/DnsSync/Core/IZoneResolver.cs
@@ -1,0 +1,14 @@
+using DnsSync.Config;
+
+namespace DnsSync.Core;
+
+public interface IZoneResolver
+{
+    /// <summary>
+    /// Returns the merged set of zones to process: explicit <c>zones:</c> entries take
+    /// precedence over zones discovered via <c>zone_groups:</c>. Emits a warning for any
+    /// zone_group zone that is overridden by an explicit zone entry.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, ZoneConfig>> ResolveAsync(
+        DnsSyncConfig config, CancellationToken cancellationToken);
+}

--- a/src/DnsSync/Core/ZoneDiff.cs
+++ b/src/DnsSync/Core/ZoneDiff.cs
@@ -30,13 +30,13 @@ public static class ZoneDiff
             .Where(r => !ShouldIgnore(r, source.Name, includeApexNs))
             .ToList();
 
-        // Group by (name, type) — DNS record sets
+        // Group by (name, type) — DNS record sets. Names are case-insensitive per RFC 1035.
         var sourceByKey = sourceRecords
-            .GroupBy(r => (r.Name, r.Type))
+            .GroupBy(r => (Name: r.Name.ToLowerInvariant(), Type: r.Type.ToUpperInvariant()))
             .ToDictionary(g => g.Key, g => g.ToList());
 
         var targetByKey = targetRecords
-            .GroupBy(r => (r.Name, r.Type))
+            .GroupBy(r => (Name: r.Name.ToLowerInvariant(), Type: r.Type.ToUpperInvariant()))
             .ToDictionary(g => g.Key, g => g.ToList());
 
         // Records in source but not in target → Create

--- a/src/DnsSync/Core/ZoneResolver.cs
+++ b/src/DnsSync/Core/ZoneResolver.cs
@@ -1,0 +1,71 @@
+using System.Text.RegularExpressions;
+using DnsSync.Config;
+using DnsSync.Providers;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace DnsSync.Core;
+
+public class ZoneResolver(ILoggerFactory loggerFactory) : IZoneResolver
+{
+    public async Task<IReadOnlyDictionary<string, ZoneConfig>> ResolveAsync(
+        DnsSyncConfig config, CancellationToken cancellationToken)
+    {
+        // Start with explicit zones — they always win.
+        var resolved = new Dictionary<string, ZoneConfig>(
+            config.Zones, StringComparer.OrdinalIgnoreCase);
+
+        if (config.ZoneGroups.Count == 0)
+            return resolved;
+
+        foreach (var (groupName, group) in config.ZoneGroups)
+        {
+            var provider = ProviderFactory.Create(
+                group.Source, config.Providers[group.Source], loggerFactory);
+
+            IReadOnlyList<string> discovered;
+            try
+            {
+                discovered = await provider.GetZonesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[yellow]⚠[/] Zone group '{Markup.Escape(groupName)}': " +
+                    $"failed to discover zones from '{Markup.Escape(group.Source)}': {Markup.Escape(ex.Message)}");
+                continue;
+            }
+
+            Regex? includeRx = group.IncludePattern is not null
+                ? new Regex(group.IncludePattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)
+                : null;
+            Regex? excludeRx = group.ExcludePattern is not null
+                ? new Regex(group.ExcludePattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)
+                : null;
+
+            foreach (var zoneName in discovered)
+            {
+                if (includeRx is not null && !includeRx.IsMatch(zoneName))
+                    continue;
+                if (excludeRx is not null && excludeRx.IsMatch(zoneName))
+                    continue;
+
+                if (resolved.ContainsKey(zoneName))
+                {
+                    AnsiConsole.MarkupLine(
+                        $"[yellow]~[/] Zone '{Markup.Escape(zoneName)}' from group " +
+                        $"'{Markup.Escape(groupName)}' overridden by explicit zones: entry");
+                    continue;
+                }
+
+                resolved[zoneName] = new ZoneConfig
+                {
+                    Source = group.Source,
+                    Targets = group.Targets,
+                };
+            }
+        }
+
+        return resolved;
+    }
+}

--- a/src/DnsSync/Program.cs
+++ b/src/DnsSync/Program.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using DnsSync.Commands;
 using DnsSync.Config;
+using DnsSync.Core;
 using DnsSync.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -97,6 +98,8 @@ var services = new ServiceCollection();
 services.AddLogging(b => b
     .ClearProviders()
     .AddSerilog(dispose: true));
+
+services.AddSingleton<IZoneResolver, ZoneResolver>();
 
 var registrar = new TypeRegistrar(services);
 var app = new CommandApp(registrar);

--- a/tests/DnsSync.Tests/Config/ConfigLoaderTests.cs
+++ b/tests/DnsSync.Tests/Config/ConfigLoaderTests.cs
@@ -295,6 +295,203 @@ public class ConfigLoaderTests
         errors.ShouldBeEmpty();
     }
 
+    // ── zone_groups: parsing ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Load_ZoneGroups_ParsesCorrectly()
+    {
+        var config = Deserialize("""
+            providers:
+              yaml_src:
+                type: yaml
+                directory: ./zones
+              cf:
+                type: cloudflare
+                api_token: tok
+            zone_groups:
+              all-com:
+                source: yaml_src
+                targets:
+                  - cf
+                include_pattern: ".*\\.com\\."
+                exclude_pattern: "staging\\..*"
+            """);
+
+        config.ZoneGroups.Count.ShouldBe(1);
+        config.ZoneGroups.ShouldContainKey("all-com");
+        var g = config.ZoneGroups["all-com"];
+        g.Source.ShouldBe("yaml_src");
+        g.Targets.ShouldContain("cf");
+        g.IncludePattern.ShouldBe(".*\\.com\\.");
+        g.ExcludePattern.ShouldBe("staging\\..*");
+    }
+
+    [Fact]
+    public void Load_ZoneGroups_WithoutPatterns_HasNullPatterns()
+    {
+        var config = Deserialize("""
+            providers:
+              yaml_src:
+                type: yaml
+                directory: ./zones
+              cf:
+                type: cloudflare
+                api_token: tok
+            zone_groups:
+              all:
+                source: yaml_src
+                targets:
+                  - cf
+            """);
+
+        var g = config.ZoneGroups["all"];
+        g.IncludePattern.ShouldBeNull();
+        g.ExcludePattern.ShouldBeNull();
+    }
+
+    // ── zone_groups: ValidateStructure ────────────────────────────────────────
+
+    [Fact]
+    public void ValidateStructure_ZoneGroups_ValidConfig_ReturnsNoErrors()
+    {
+        var config = Deserialize("""
+            providers:
+              yaml_src:
+                type: yaml
+                directory: ./zones
+              cf:
+                type: cloudflare
+                api_token: tok
+            zone_groups:
+              all:
+                source: yaml_src
+                targets:
+                  - cf
+            """);
+
+        ConfigLoader.ValidateStructure(config).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ValidateStructure_NoZonesButHasZoneGroups_IsValid()
+    {
+        var config = Deserialize("""
+            providers:
+              yaml_src:
+                type: yaml
+                directory: ./zones
+              cf:
+                type: cloudflare
+                api_token: tok
+            zone_groups:
+              all:
+                source: yaml_src
+                targets:
+                  - cf
+            """);
+
+        // zone_groups alone satisfies the "at least zones or zone_groups" requirement
+        ConfigLoader.ValidateStructure(config).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ValidateStructure_ZoneGroups_UnknownSource_ReturnsError()
+    {
+        var config = Deserialize("""
+            providers:
+              cf:
+                type: cloudflare
+                api_token: tok
+            zone_groups:
+              all:
+                source: nonexistent
+                targets:
+                  - cf
+            """);
+
+        var errors = ConfigLoader.ValidateStructure(config);
+        errors.ShouldContain(e => e.Contains("nonexistent") && e.Contains("source"));
+    }
+
+    [Fact]
+    public void ValidateStructure_ZoneGroups_UnknownTarget_ReturnsError()
+    {
+        var config = Deserialize("""
+            providers:
+              yaml_src:
+                type: yaml
+                directory: ./zones
+            zone_groups:
+              all:
+                source: yaml_src
+                targets:
+                  - ghost_provider
+            """);
+
+        var errors = ConfigLoader.ValidateStructure(config);
+        errors.ShouldContain(e => e.Contains("ghost_provider"));
+    }
+
+    [Fact]
+    public void ValidateStructure_ZoneGroups_SameSourceAndTarget_ReturnsError()
+    {
+        var config = Deserialize("""
+            providers:
+              cf:
+                type: cloudflare
+                api_token: tok
+            zone_groups:
+              all:
+                source: cf
+                targets:
+                  - cf
+            """);
+
+        var errors = ConfigLoader.ValidateStructure(config);
+        errors.ShouldContain(e => e.Contains("source and target") || e.Contains("both source"));
+    }
+
+    [Fact]
+    public void ValidateStructure_ZoneGroups_ReadOnlyTarget_ReturnsError()
+    {
+        var config = Deserialize("""
+            providers:
+              yaml_src:
+                type: yaml
+                directory: ./zones
+              readonly_cf:
+                type: cloudflare
+                api_token: tok
+                readonly: true
+            zone_groups:
+              all:
+                source: yaml_src
+                targets:
+                  - readonly_cf
+            """);
+
+        var errors = ConfigLoader.ValidateStructure(config);
+        errors.ShouldContain(e => e.Contains("read-only") || e.Contains("readonly"));
+    }
+
+    [Fact]
+    public void ValidateStructure_ZoneGroups_EmptyTargets_ReturnsError()
+    {
+        var config = Deserialize("""
+            providers:
+              yaml_src:
+                type: yaml
+                directory: ./zones
+            zone_groups:
+              all:
+                source: yaml_src
+                targets: []
+            """);
+
+        var errors = ConfigLoader.ValidateStructure(config);
+        errors.ShouldContain(e => e.Contains("target") || e.Contains("all"));
+    }
+
     private static DnsSyncConfig Deserialize(string yaml)
     {
         var tmp = Path.GetTempFileName();

--- a/tests/DnsSync.Tests/Core/ZoneDiffEdgeCaseTests.cs
+++ b/tests/DnsSync.Tests/Core/ZoneDiffEdgeCaseTests.cs
@@ -246,7 +246,7 @@ public class ZoneDiffEdgeCaseTests
             {
                 Name = "alias.example.com.",
                 Type = "CNAME",
-                Ttl  = 300,
+                Ttl = 300,
                 Target = "host.example.com."
             });
 

--- a/tests/DnsSync.Tests/Core/ZoneDiffEdgeCaseTests.cs
+++ b/tests/DnsSync.Tests/Core/ZoneDiffEdgeCaseTests.cs
@@ -1,0 +1,263 @@
+using DnsSync.Core;
+using DnsSync.Core.Records;
+using Shouldly;
+
+namespace DnsSync.Tests.Core;
+
+/// <summary>
+/// Edge-case tests for ZoneDiff: empty zones, wildcards, case sensitivity,
+/// SOA filtering, apex-NS filtering, TTL-only changes, and mixed change types.
+/// </summary>
+public class ZoneDiffEdgeCaseTests
+{
+    private static DnsZone Empty(string name = "example.com.") =>
+        new() { Name = name, Records = [] };
+
+    private static DnsZone ZoneWith(string name, params DnsRecord[] records) =>
+        new() { Name = name, Records = records };
+
+    private static ARecord ARecord(string fqdn, int ttl = 300, string ip = "1.2.3.4") =>
+        new() { Name = fqdn, Type = "A", Ttl = ttl, Addresses = [ip] };
+
+    private static NsRecord ApexNs(string zone = "example.com.", string ns = "ns1.example.com.") =>
+        new() { Name = zone, Type = "NS", Ttl = 3600, Nameservers = [ns] };
+
+    // ── both zones empty ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_BothZonesEmpty_ProducesNoPlan()
+    {
+        var plan = ZoneDiff.Diff(Empty(), Empty());
+
+        plan.IsEmpty.ShouldBeTrue();
+        plan.Total.ShouldBe(0);
+    }
+
+    // ── source empty ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_SourceEmpty_TargetHasRecords_AllDeletes()
+    {
+        var target = ZoneWith("example.com.",
+            ARecord("www.example.com."),
+            ARecord("api.example.com."));
+
+        var plan = ZoneDiff.Diff(Empty(), target);
+
+        plan.Deletes.ShouldBe(2);
+        plan.Creates.ShouldBe(0);
+        plan.Updates.ShouldBe(0);
+    }
+
+    // ── target empty ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_TargetEmpty_SourceHasRecords_AllCreates()
+    {
+        var source = ZoneWith("example.com.",
+            ARecord("www.example.com."),
+            ARecord("api.example.com."));
+
+        var plan = ZoneDiff.Diff(source, Empty());
+
+        plan.Creates.ShouldBe(2);
+        plan.Deletes.ShouldBe(0);
+        plan.Updates.ShouldBe(0);
+    }
+
+    // ── wildcard records ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_WildcardRecord_TreatedAsNormalRecordName()
+    {
+        var source = ZoneWith("example.com.",
+            ARecord("*.example.com."));
+        var target = Empty();
+
+        var plan = ZoneDiff.Diff(source, target);
+
+        plan.Creates.ShouldBe(1);
+        plan.Changes[0].After!.Name.ShouldBe("*.example.com.");
+    }
+
+    [Fact]
+    public void Diff_WildcardSourceAndTarget_Identical_ProducesNoPlan()
+    {
+        var record = ARecord("*.example.com.");
+        var source = ZoneWith("example.com.", record);
+        var target = ZoneWith("example.com.", ARecord("*.example.com."));
+
+        var plan = ZoneDiff.Diff(source, target);
+
+        plan.IsEmpty.ShouldBeTrue();
+    }
+
+    // ── case sensitivity in record names ─────────────────────────────────────
+
+    [Fact]
+    public void Diff_RecordNamesAreCaseSensitive_TreatedAsDistinct()
+    {
+        // ZoneDiff compares record names as-is (case-sensitive). Providers are expected
+        // to normalize to lowercase before passing records to ZoneDiff.
+        var source = ZoneWith("example.com.", ARecord("WWW.EXAMPLE.COM."));
+        var target = ZoneWith("example.com.", ARecord("www.example.com."));
+
+        var plan = ZoneDiff.Diff(source, target);
+
+        // Different case → treated as different records
+        plan.Creates.ShouldBe(1); // WWW.EXAMPLE.COM. not in target
+        plan.Deletes.ShouldBe(1); // www.example.com. not in source
+    }
+
+    // ── SOA is always ignored ─────────────────────────────────────────────────
+    // DnsRecord is abstract; use ARecord with Type="SOA" to simulate SOA records
+    // in tests — ZoneDiff filters by Type string regardless of C# type.
+
+    private static ARecord SoaRecord() =>
+        new() { Name = "example.com.", Type = "SOA", Ttl = 3600, Addresses = [] };
+
+    [Fact]
+    public void Diff_BothSidesHaveSoa_NoDiff()
+    {
+        var source = ZoneWith("example.com.", SoaRecord());
+        var target = ZoneWith("example.com.", SoaRecord());
+
+        var plan = ZoneDiff.Diff(source, target);
+
+        plan.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Diff_SoaOnlyInSource_IsIgnored()
+    {
+        var source = ZoneWith("example.com.", SoaRecord());
+
+        var plan = ZoneDiff.Diff(source, Empty());
+
+        plan.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Diff_SoaOnlyInTarget_IsIgnored()
+    {
+        var target = ZoneWith("example.com.", SoaRecord());
+
+        var plan = ZoneDiff.Diff(Empty(), target);
+
+        plan.IsEmpty.ShouldBeTrue();
+    }
+
+    // ── apex NS filtering ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_ApexNs_ExcludedByDefault_EvenWhenDifferent()
+    {
+        var source = ZoneWith("example.com.", ApexNs(ns: "ns1.source.com."));
+        var target = ZoneWith("example.com.", ApexNs(ns: "ns1.target.com."));
+
+        var plan = ZoneDiff.Diff(source, target, includeApexNs: false);
+
+        plan.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Diff_ApexNs_IncludedWhenFlagSet_ProducesUpdate()
+    {
+        var source = ZoneWith("example.com.", ApexNs(ns: "ns1.source.com."));
+        var target = ZoneWith("example.com.", ApexNs(ns: "ns1.target.com."));
+
+        var plan = ZoneDiff.Diff(source, target, includeApexNs: true);
+
+        plan.IsEmpty.ShouldBeFalse();
+        plan.Updates.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Diff_SubdomainNs_NotFiltered()
+    {
+        var ns = new NsRecord
+        {
+            Name = "sub.example.com.",
+            Type = "NS",
+            Ttl = 3600,
+            Nameservers = ["ns1.example.com."]
+        };
+        var source = ZoneWith("example.com.", ns);
+
+        var plan = ZoneDiff.Diff(source, Empty());
+
+        plan.Creates.ShouldBe(1);
+    }
+
+    // ── TTL-only changes ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_TtlOnly_IsTtlOnlyChangeTrue()
+    {
+        var source = ZoneWith("example.com.", ARecord("www.example.com.", ttl: 60));
+        var target = ZoneWith("example.com.", ARecord("www.example.com.", ttl: 3600));
+
+        var plan = ZoneDiff.Diff(source, target);
+
+        plan.Updates.ShouldBe(1);
+        plan.Changes[0].IsTtlOnlyChange.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Diff_BothTtlAndValueChange_IsNotTtlOnly()
+    {
+        var source = ZoneWith("example.com.", ARecord("www.example.com.", ttl: 60, ip: "1.1.1.1"));
+        var target = ZoneWith("example.com.", ARecord("www.example.com.", ttl: 3600, ip: "2.2.2.2"));
+
+        var plan = ZoneDiff.Diff(source, target);
+
+        plan.Updates.ShouldBe(1);
+        plan.Changes[0].IsTtlOnlyChange.ShouldBeFalse();
+    }
+
+    // ── mixed changes ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Diff_CreateUpdateDelete_CountsCorrect()
+    {
+        var source = ZoneWith("example.com.",
+            ARecord("new.example.com."),                            // create
+            ARecord("changed.example.com.", ip: "9.9.9.9"),         // update
+            ARecord("unchanged.example.com."));                     // no change
+
+        var target = ZoneWith("example.com.",
+            ARecord("changed.example.com.", ip: "1.1.1.1"),         // will be updated
+            ARecord("unchanged.example.com."),                      // unchanged
+            ARecord("deleted.example.com."));                       // delete
+
+        var plan = ZoneDiff.Diff(source, target);
+
+        plan.Creates.ShouldBe(1);
+        plan.Updates.ShouldBe(1);
+        plan.Deletes.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Diff_MultipleRRsetsAtSameName_EachDiffedIndependently()
+    {
+        // Both A and CNAME at different names — each diffed as its own RRset
+        var source = ZoneWith("example.com.",
+            ARecord("host.example.com.", ip: "1.1.1.1"),
+            new CnameRecord
+            {
+                Name = "alias.example.com.",
+                Type = "CNAME",
+                Ttl  = 300,
+                Target = "host.example.com."
+            });
+
+        var target = ZoneWith("example.com.",
+            ARecord("host.example.com.", ip: "2.2.2.2")); // changed IP; alias gone → delete
+
+        var plan = ZoneDiff.Diff(source, target);
+
+        plan.Updates.ShouldBe(1); // A record IP changed
+        plan.Creates.ShouldBe(1); // CNAME now only in source → create on target? No — target lacks it → create
+        plan.Deletes.ShouldBe(0);
+    }
+}

--- a/tests/DnsSync.Tests/Core/ZoneDiffEdgeCaseTests.cs
+++ b/tests/DnsSync.Tests/Core/ZoneDiffEdgeCaseTests.cs
@@ -95,18 +95,17 @@ public class ZoneDiffEdgeCaseTests
     // ── case sensitivity in record names ─────────────────────────────────────
 
     [Fact]
-    public void Diff_RecordNamesAreCaseSensitive_TreatedAsDistinct()
+    public void Diff_RecordNamesAreCaseInsensitive_IdenticalZones_ProducesNoPlan()
     {
-        // ZoneDiff compares record names as-is (case-sensitive). Providers are expected
-        // to normalize to lowercase before passing records to ZoneDiff.
+        // DNS names are case-insensitive per RFC 1035. ZoneDiff normalizes before comparing.
         var source = ZoneWith("example.com.", ARecord("WWW.EXAMPLE.COM."));
         var target = ZoneWith("example.com.", ARecord("www.example.com."));
 
         var plan = ZoneDiff.Diff(source, target);
 
-        // Different case → treated as different records
-        plan.Creates.ShouldBe(1); // WWW.EXAMPLE.COM. not in target
-        plan.Deletes.ShouldBe(1); // www.example.com. not in source
+        plan.Creates.ShouldBe(0);
+        plan.Deletes.ShouldBe(0);
+        plan.IsEmpty.ShouldBeTrue();
     }
 
     // ── SOA is always ignored ─────────────────────────────────────────────────

--- a/tests/DnsSync.Tests/Core/ZoneResolverTests.cs
+++ b/tests/DnsSync.Tests/Core/ZoneResolverTests.cs
@@ -39,14 +39,14 @@ public class ZoneResolverTests : IDisposable
             Providers = new()
             {
                 ["yaml_src"] = new() { Type = "yaml", Directory = _dir },
-                ["cf"]       = new() { Type = "cloudflare", ApiToken = "tok" },
+                ["cf"] = new() { Type = "cloudflare", ApiToken = "tok" },
             },
             ZoneGroups = new()
             {
                 ["all"] = new()
                 {
-                    Source         = groupSource,
-                    Targets        = ["cf"],
+                    Source = groupSource,
+                    Targets = ["cf"],
                     IncludePattern = includePattern,
                     ExcludePattern = excludePattern,
                 }
@@ -61,7 +61,7 @@ public class ZoneResolverTests : IDisposable
         var config = new DnsSyncConfig
         {
             Providers = new() { ["cf"] = new() { Type = "cloudflare", ApiToken = "tok" } },
-            Zones     = new() { ["example.com."] = new() { Source = "cf", Targets = ["cf"] } }
+            Zones = new() { ["example.com."] = new() { Source = "cf", Targets = ["cf"] } }
         };
 
         var result = await _resolver.ResolveAsync(config, default);
@@ -265,7 +265,7 @@ public class ZoneResolverTests : IDisposable
                 {
                     ["yaml1"] = new() { Type = "yaml", Directory = _dir },
                     ["yaml2"] = new() { Type = "yaml", Directory = dir2 },
-                    ["cf"]    = new() { Type = "cloudflare", ApiToken = "tok" },
+                    ["cf"] = new() { Type = "cloudflare", ApiToken = "tok" },
                 },
                 ZoneGroups = new()
                 {
@@ -301,8 +301,8 @@ public class ZoneResolverTests : IDisposable
                 {
                     ["yaml1"] = new() { Type = "yaml", Directory = _dir },
                     ["yaml2"] = new() { Type = "yaml", Directory = dir2 },
-                    ["cf"]    = new() { Type = "cloudflare", ApiToken = "tok" },
-                    ["pb"]    = new() { Type = "porkbun", ApiKey = "k", SecretKey = "s" },
+                    ["cf"] = new() { Type = "cloudflare", ApiToken = "tok" },
+                    ["pb"] = new() { Type = "porkbun", ApiKey = "k", SecretKey = "s" },
                 },
                 ZoneGroups = new()
                 {
@@ -335,9 +335,9 @@ public class ZoneResolverTests : IDisposable
             Providers = new()
             {
                 ["missing"] = new() { Type = "yaml", Directory = "/nonexistent-xyz-path" },
-                ["cf"]      = new() { Type = "cloudflare", ApiToken = "tok" },
+                ["cf"] = new() { Type = "cloudflare", ApiToken = "tok" },
             },
-            Zones      = new() { ["explicit.com."] = new() { Source = "cf", Targets = ["cf"] } },
+            Zones = new() { ["explicit.com."] = new() { Source = "cf", Targets = ["cf"] } },
             ZoneGroups = new() { ["bad"] = new() { Source = "missing", Targets = ["cf"] } }
         };
 

--- a/tests/DnsSync.Tests/Core/ZoneResolverTests.cs
+++ b/tests/DnsSync.Tests/Core/ZoneResolverTests.cs
@@ -1,0 +1,366 @@
+using DnsSync.Config;
+using DnsSync.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace DnsSync.Tests.Core;
+
+/// <summary>
+/// Tests for ZoneResolver — merging explicit zones with zone_groups discovery.
+/// Uses YamlProvider with temp directories to avoid requiring external API credentials.
+/// </summary>
+public class ZoneResolverTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly ZoneResolver _resolver;
+
+    public ZoneResolverTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "dns-sync-zr-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _resolver = new ZoneResolver(NullLoggerFactory.Instance);
+    }
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private void CreateZoneFile(string fqdn) =>
+        File.WriteAllText(
+            Path.Combine(_dir, fqdn.TrimEnd('.') + ".yaml"),
+            $"'': \n  type: A\n  ttl: 300\n  value: 1.2.3.4\n");
+
+    private DnsSyncConfig ConfigWithYamlGroup(
+        string? includePattern = null,
+        string? excludePattern = null,
+        string groupSource = "yaml_src") =>
+        new()
+        {
+            Providers = new()
+            {
+                ["yaml_src"] = new() { Type = "yaml", Directory = _dir },
+                ["cf"]       = new() { Type = "cloudflare", ApiToken = "tok" },
+            },
+            ZoneGroups = new()
+            {
+                ["all"] = new()
+                {
+                    Source         = groupSource,
+                    Targets        = ["cf"],
+                    IncludePattern = includePattern,
+                    ExcludePattern = excludePattern,
+                }
+            }
+        };
+
+    // ── no zone_groups ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_NoZoneGroups_ReturnsOnlyExplicitZones()
+    {
+        var config = new DnsSyncConfig
+        {
+            Providers = new() { ["cf"] = new() { Type = "cloudflare", ApiToken = "tok" } },
+            Zones     = new() { ["example.com."] = new() { Source = "cf", Targets = ["cf"] } }
+        };
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.Count.ShouldBe(1);
+        result.ContainsKey("example.com.").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_EmptyConfig_ReturnsEmptyDictionary()
+    {
+        var result = await _resolver.ResolveAsync(new DnsSyncConfig(), default);
+        result.ShouldBeEmpty();
+    }
+
+    // ── basic discovery ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_ZoneGroupWithMatchingFiles_DiscoversAllZones()
+    {
+        CreateZoneFile("example.com.");
+        CreateZoneFile("other.net.");
+        var config = ConfigWithYamlGroup();
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ContainsKey("example.com.").ShouldBeTrue();
+        result.ContainsKey("other.net.").ShouldBeTrue();
+        result["example.com."].Source.ShouldBe("yaml_src");
+        result["example.com."].Targets.ShouldContain("cf");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_EmptyDirectory_ReturnsNoDiscoveredZones()
+    {
+        var config = ConfigWithYamlGroup();
+        var result = await _resolver.ResolveAsync(config, default);
+        result.ShouldBeEmpty();
+    }
+
+    // ── explicit zones take precedence ────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_ExplicitZoneOverridesGroupZone_UsesExplicitTargets()
+    {
+        CreateZoneFile("example.com.");
+        var config = ConfigWithYamlGroup();
+        // Override with different targets list to verify which one wins
+        config.Providers["cf2"] = new() { Type = "cloudflare", ApiToken = "tok2" };
+        config.Zones["example.com."] = new() { Source = "yaml_src", Targets = ["cf2"] };
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ContainsKey("example.com.").ShouldBeTrue();
+        result["example.com."].Targets.ShouldContain("cf2");
+        result["example.com."].Targets.ShouldNotContain("cf");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ExplicitZonePlusGroupZones_MergesWithoutDuplicates()
+    {
+        CreateZoneFile("discovered.com.");
+        var config = ConfigWithYamlGroup();
+        config.Zones["explicit.com."] = new() { Source = "yaml_src", Targets = ["cf"] };
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ContainsKey("explicit.com.").ShouldBeTrue();
+        result.ContainsKey("discovered.com.").ShouldBeTrue();
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ZoneInBothExplicitAndGroup_ExactlyOneEntry()
+    {
+        CreateZoneFile("example.com.");
+        var config = ConfigWithYamlGroup();
+        config.Zones["example.com."] = new() { Source = "yaml_src", Targets = ["cf"] };
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.Count(kvp => string.Equals(kvp.Key, "example.com.", StringComparison.OrdinalIgnoreCase))
+              .ShouldBe(1);
+    }
+
+    // ── include_pattern ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_IncludePattern_OnlyIncludesMatchingZones()
+    {
+        CreateZoneFile("keep.com.");
+        CreateZoneFile("skip.net.");
+        var config = ConfigWithYamlGroup(includePattern: @"\.com\.$");
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ContainsKey("keep.com.").ShouldBeTrue();
+        result.ContainsKey("skip.net.").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_IncludePattern_NoMatches_ReturnsEmpty()
+    {
+        CreateZoneFile("example.com.");
+        var config = ConfigWithYamlGroup(includePattern: @"\.io\.$");
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_IncludePattern_MatchesAll_ReturnsAll()
+    {
+        CreateZoneFile("alpha.com.");
+        CreateZoneFile("beta.net.");
+        var config = ConfigWithYamlGroup(includePattern: ".*");
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.Count.ShouldBe(2);
+    }
+
+    // ── exclude_pattern ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_ExcludePattern_RemovesMatchingZones()
+    {
+        CreateZoneFile("prod.com.");
+        CreateZoneFile("staging.com.");
+        var config = ConfigWithYamlGroup(excludePattern: "^staging");
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ContainsKey("prod.com.").ShouldBeTrue();
+        result.ContainsKey("staging.com.").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ExcludePattern_ExcludesAll_ReturnsEmpty()
+    {
+        CreateZoneFile("example.com.");
+        var config = ConfigWithYamlGroup(excludePattern: ".*");
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ShouldBeEmpty();
+    }
+
+    // ── include + exclude combined ────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_IncludeAndExclude_ExcludeTakesPrecedenceWithinIncludedSet()
+    {
+        CreateZoneFile("prod.com.");
+        CreateZoneFile("staging.com.");
+        CreateZoneFile("dev.net.");
+        var config = ConfigWithYamlGroup(
+            includePattern: @"\.com\.$",
+            excludePattern: "^staging");
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ContainsKey("prod.com.").ShouldBeTrue();
+        result.ContainsKey("staging.com.").ShouldBeFalse(); // excluded
+        result.ContainsKey("dev.net.").ShouldBeFalse();      // not included
+    }
+
+    // ── case insensitivity ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_ZoneKeys_CaseInsensitiveDeduplication()
+    {
+        CreateZoneFile("example.com.");
+        var config = ConfigWithYamlGroup();
+        // Explicit key in different case
+        config.Zones["EXAMPLE.COM."] = new() { Source = "yaml_src", Targets = ["cf"] };
+
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.Count(kvp => kvp.Key.Equals("example.com.", StringComparison.OrdinalIgnoreCase))
+              .ShouldBe(1);
+    }
+
+    // ── multiple zone groups ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_MultipleZoneGroups_AllDiscovered()
+    {
+        var dir2 = Path.Combine(Path.GetTempPath(), "dns-sync-zr2-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir2);
+        try
+        {
+            CreateZoneFile("from-dir1.com.");
+            File.WriteAllText(Path.Combine(dir2, "from-dir2.com.yaml"),
+                "'': \n  type: A\n  ttl: 300\n  value: 2.2.2.2\n");
+
+            var config = new DnsSyncConfig
+            {
+                Providers = new()
+                {
+                    ["yaml1"] = new() { Type = "yaml", Directory = _dir },
+                    ["yaml2"] = new() { Type = "yaml", Directory = dir2 },
+                    ["cf"]    = new() { Type = "cloudflare", ApiToken = "tok" },
+                },
+                ZoneGroups = new()
+                {
+                    ["g1"] = new() { Source = "yaml1", Targets = ["cf"] },
+                    ["g2"] = new() { Source = "yaml2", Targets = ["cf"] },
+                }
+            };
+
+            var result = await _resolver.ResolveAsync(config, default);
+
+            result.ContainsKey("from-dir1.com.").ShouldBeTrue();
+            result.ContainsKey("from-dir2.com.").ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(dir2, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveAsync_MultipleGroups_SameZoneInBoth_FirstGroupWins()
+    {
+        var dir2 = Path.Combine(Path.GetTempPath(), "dns-sync-zr3-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir2);
+        try
+        {
+            CreateZoneFile("shared.com.");
+            File.WriteAllText(Path.Combine(dir2, "shared.com.yaml"),
+                "'': \n  type: A\n  ttl: 300\n  value: 2.2.2.2\n");
+            var config = new DnsSyncConfig
+            {
+                Providers = new()
+                {
+                    ["yaml1"] = new() { Type = "yaml", Directory = _dir },
+                    ["yaml2"] = new() { Type = "yaml", Directory = dir2 },
+                    ["cf"]    = new() { Type = "cloudflare", ApiToken = "tok" },
+                    ["pb"]    = new() { Type = "porkbun", ApiKey = "k", SecretKey = "s" },
+                },
+                ZoneGroups = new()
+                {
+                    ["g1"] = new() { Source = "yaml1", Targets = ["cf"] },
+                    ["g2"] = new() { Source = "yaml2", Targets = ["pb"] },
+                }
+            };
+
+            var result = await _resolver.ResolveAsync(config, default);
+
+            // shared.com. should appear exactly once
+            result.Count(kvp => kvp.Key.Equals("shared.com.", StringComparison.OrdinalIgnoreCase))
+                  .ShouldBe(1);
+            // First group wins → targets = ["cf"]
+            result["shared.com."].Targets.ShouldContain("cf");
+        }
+        finally
+        {
+            Directory.Delete(dir2, recursive: true);
+        }
+    }
+
+    // ── failure resilience ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_ProviderDirectoryMissing_DoesNotThrow_ReturnsExplicitZones()
+    {
+        var config = new DnsSyncConfig
+        {
+            Providers = new()
+            {
+                ["missing"] = new() { Type = "yaml", Directory = "/nonexistent-xyz-path" },
+                ["cf"]      = new() { Type = "cloudflare", ApiToken = "tok" },
+            },
+            Zones      = new() { ["explicit.com."] = new() { Source = "cf", Targets = ["cf"] } },
+            ZoneGroups = new() { ["bad"] = new() { Source = "missing", Targets = ["cf"] } }
+        };
+
+        // Must not throw — warns and continues
+        var result = await _resolver.ResolveAsync(config, default);
+
+        result.ContainsKey("explicit.com.").ShouldBeTrue();
+    }
+
+    // ── cancellation ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveAsync_CancelledToken_CompletesOrThrowsOperationCancelled()
+    {
+        CreateZoneFile("example.com.");
+        var config = ConfigWithYamlGroup();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // YAML provider does not respect CT on file reads — acceptable;
+        // just ensure no unrelated exception escapes.
+        var ex = await Record.ExceptionAsync(() => _resolver.ResolveAsync(config, cts.Token));
+
+        (ex is null || ex is OperationCanceledException).ShouldBeTrue();
+    }
+}

--- a/tests/DnsSync.Tests/Providers/Yaml/YamlProviderEdgeCaseTests.cs
+++ b/tests/DnsSync.Tests/Providers/Yaml/YamlProviderEdgeCaseTests.cs
@@ -1,0 +1,278 @@
+using DnsSync.Core.Records;
+using DnsSync.Providers.Yaml;
+using Shouldly;
+
+namespace DnsSync.Tests.Providers.Yaml;
+
+/// <summary>
+/// Edge-case tests for YamlProvider: filesystem edge cases (spaces in path, hyphens,
+/// non-YAML files), malformed YAML, TTL defaults, TXT escape handling, and
+/// GetZonesAsync zone name normalization.
+/// </summary>
+public class YamlProviderEdgeCaseTests : IDisposable
+{
+    private readonly string _dir;
+
+    public YamlProviderEdgeCaseTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "dns sync edge-cases " + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string Write(string filename, string content)
+    {
+        var path = Path.Combine(_dir, filename);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    // ── filesystem edge cases ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetZoneAsync_DirectoryPathWithSpaces_ReadsCorrectly()
+    {
+        // _dir already contains spaces in the path ("dns sync edge-cases …")
+        Write("example.com.yaml",
+            "'': \n  type: A\n  ttl: 300\n  value: 1.2.3.4\n");
+
+        var provider = new YamlProvider(_dir);
+        var zone = await provider.GetZoneAsync("example.com.");
+
+        zone.Records.OfType<ARecord>().Single().Addresses.ShouldContain("1.2.3.4");
+    }
+
+    [Fact]
+    public async Task GetZoneAsync_ZoneNameWithHyphens_ReadsCorrectly()
+    {
+        Write("my-zone.com.yaml",
+            "'': \n  type: A\n  ttl: 300\n  value: 5.6.7.8\n");
+
+        var provider = new YamlProvider(_dir);
+        var zone = await provider.GetZoneAsync("my-zone.com.");
+
+        zone.Name.ShouldBe("my-zone.com.");
+        zone.Records.OfType<ARecord>().Single().Addresses.ShouldContain("5.6.7.8");
+    }
+
+    [Fact]
+    public async Task GetZoneAsync_ZoneNameWithSubdomain_ReadsCorrectly()
+    {
+        Write("sub.example.com.yaml",
+            "www: \n  type: A\n  ttl: 300\n  value: 9.9.9.9\n");
+
+        var provider = new YamlProvider(_dir);
+        var zone = await provider.GetZoneAsync("sub.example.com.");
+
+        zone.Name.ShouldBe("sub.example.com.");
+        zone.Records.OfType<ARecord>().Single().Name.ShouldBe("www.sub.example.com.");
+    }
+
+    [Fact]
+    public async Task GetZoneAsync_MissingFile_ThrowsFileNotFoundException()
+    {
+        var provider = new YamlProvider(_dir);
+        await Should.ThrowAsync<FileNotFoundException>(
+            () => provider.GetZoneAsync("doesnotexist.com."));
+    }
+
+    [Fact]
+    public async Task PreflightAsync_DirectoryMissing_ThrowsDirectoryNotFoundException()
+    {
+        var provider = new YamlProvider("/nonexistent-dir-xyz-123");
+        await Should.ThrowAsync<DirectoryNotFoundException>(
+            () => provider.PreflightAsync());
+    }
+
+    // ── GetZonesAsync ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetZonesAsync_EmptyDirectory_ReturnsEmpty()
+    {
+        var provider = new YamlProvider(_dir);
+        var zones = await provider.GetZonesAsync();
+        zones.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetZonesAsync_DirectoryWithNonYamlFiles_OnlyReturnsYamlZones()
+    {
+        Write("example.com.yaml", "'': \n  type: A\n  ttl: 300\n  value: 1.2.3.4\n");
+        Write("readme.txt", "not a zone");
+        Write("example.json", "{}");
+        Write("backup.bak", "old data");
+        Write("notes.md", "# notes");
+
+        var provider = new YamlProvider(_dir);
+        var zones = await provider.GetZonesAsync();
+
+        zones.Count.ShouldBe(1);
+        zones.ShouldContain("example.com.");
+    }
+
+    [Fact]
+    public async Task GetZonesAsync_ZoneFileNames_NormalizedToFqdn()
+    {
+        // Zone files without trailing dot → should be normalized to FQDN with trailing dot
+        Write("example.com.yaml", "'': \n  type: A\n  ttl: 300\n  value: 1.2.3.4\n");
+
+        var provider = new YamlProvider(_dir);
+        var zones = await provider.GetZonesAsync();
+
+        zones.Single().ShouldEndWith(".");
+    }
+
+    [Fact]
+    public async Task GetZonesAsync_MultipleZoneFiles_ReturnsAll()
+    {
+        Write("alpha.com.yaml", "'': \n  type: A\n  ttl: 300\n  value: 1.1.1.1\n");
+        Write("beta.net.yaml", "'': \n  type: A\n  ttl: 300\n  value: 2.2.2.2\n");
+        Write("gamma.io.yaml", "'': \n  type: A\n  ttl: 300\n  value: 3.3.3.3\n");
+
+        var provider = new YamlProvider(_dir);
+        var zones = await provider.GetZonesAsync();
+
+        zones.Count.ShouldBe(3);
+    }
+
+    // ── malformed / incomplete YAML ───────────────────────────────────────────
+
+    [Fact]
+    public void ParseZoneYaml_EmptyFile_ReturnsNoRecords()
+    {
+        var records = YamlProvider.ParseZoneYaml("", "example.com.");
+        records.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseZoneYaml_OnlyComments_ReturnsNoRecords()
+    {
+        var yaml = "# This file has only comments\n# No records here\n";
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        records.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseZoneYaml_UnknownRecordType_IsSkipped()
+    {
+        var yaml = """
+            www:
+              type: UNKNOWN
+              ttl: 300
+              value: 1.2.3.4
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        records.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseZoneYaml_RecordWithNoType_IsSkipped()
+    {
+        var yaml = """
+            www:
+              ttl: 300
+              value: 1.2.3.4
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        records.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseZoneYaml_RecordWithNoTtl_DefaultsTo3600()
+    {
+        var yaml = """
+            www:
+              type: A
+              value: 1.2.3.4
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        records.OfType<ARecord>().Single().Ttl.ShouldBe(3600);
+    }
+
+    [Fact]
+    public void ParseZoneYaml_TxtWithSemicolonEscape_UnescapesCorrectly()
+    {
+        // octodns / Porkbun emit \; — should be normalized to ;
+        var yaml = """
+            '':
+              type: TXT
+              ttl: 300
+              value: v=spf1 include:example.com\; -all
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        var txt = records.OfType<TxtRecord>().Single();
+        txt.Values.Single().ShouldBe("v=spf1 include:example.com; -all");
+        txt.Values.Single().ShouldNotContain("\\;");
+    }
+
+    // ── YAML key edge cases ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseZoneYaml_SubdomainKeyAtSign_IsApex()
+    {
+        var yaml = """
+            '@':
+              type: A
+              ttl: 300
+              value: 1.2.3.4
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        records.OfType<ARecord>().Single().Name.ShouldBe("example.com.");
+    }
+
+    [Fact]
+    public void ParseZoneYaml_SubdomainKeyEmpty_IsApex()
+    {
+        var yaml = """
+            '':
+              type: A
+              ttl: 300
+              value: 1.2.3.4
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        records.OfType<ARecord>().Single().Name.ShouldBe("example.com.");
+    }
+
+    [Fact]
+    public void ParseZoneYaml_AbsoluteFqdnKey_PreservedAsIs()
+    {
+        // Key ending with '.' is treated as absolute FQDN, not relative
+        var yaml = """
+            other.example.com.:
+              type: A
+              ttl: 300
+              value: 2.2.2.2
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        records.OfType<ARecord>().Single().Name.ShouldBe("other.example.com.");
+    }
+
+    [Fact]
+    public void ParseZoneYaml_ListFormWithUnknownType_SkipsUnknownKeepsValid()
+    {
+        var yaml = """
+            '':
+              -
+                type: A
+                ttl: 300
+                value: 1.2.3.4
+              -
+                type: BOGUS
+                ttl: 300
+                value: nonsense
+            """;
+
+        var records = YamlProvider.ParseZoneYaml(yaml, "example.com.");
+        // Only the A record should survive
+        records.Count.ShouldBe(1);
+        records.OfType<ARecord>().ShouldHaveSingleItem();
+    }
+}

--- a/tests/DnsSync.Tests/Providers/Yaml/ZoneYamlSerializerEdgeCaseTests.cs
+++ b/tests/DnsSync.Tests/Providers/Yaml/ZoneYamlSerializerEdgeCaseTests.cs
@@ -1,0 +1,300 @@
+using DnsSync.Core;
+using DnsSync.Core.Records;
+using DnsSync.Providers.Yaml;
+using Shouldly;
+
+namespace DnsSync.Tests.Providers.Yaml;
+
+/// <summary>
+/// Edge-case tests for ZoneYamlSerializer focusing on QuoteScalar (A/AAAA/NS values)
+/// and QuoteTxt (TXT values) — all via round-trip through Serialize → ParseZoneYaml.
+/// </summary>
+public class ZoneYamlSerializerEdgeCaseTests
+{
+    private const string Zone = "example.com.";
+
+    private static DnsZone MakeZone(params DnsRecord[] records) =>
+        new() { Name = Zone, Records = records };
+
+    private static string Roundtrip(DnsZone zone)
+    {
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        return yaml;
+    }
+
+    private static IReadOnlyList<DnsRecord> RoundtripParsed(DnsZone zone) =>
+        YamlProvider.ParseZoneYaml(ZoneYamlSerializer.Serialize(zone), Zone);
+
+    // ── QuoteScalar — A record addresses ─────────────────────────────────────
+
+    [Fact]
+    public void Serialize_ARecord_AtSignValue_IsQuotedAndRoundTrips()
+    {
+        // "@." is not a valid IP but providers may emit odd values; serializer must quote it.
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["@."]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        yaml.ShouldContain("\"@.\"");
+
+        // Round-trip preserves the value
+        var parsed = YamlProvider.ParseZoneYaml(yaml, Zone);
+        parsed.OfType<ARecord>().Single().Addresses.ShouldContain("@.");
+    }
+
+    [Fact]
+    public void Serialize_ARecord_BacktickValue_IsQuotedAndRoundTrips()
+    {
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["`value`"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        yaml.ShouldContain("\"`value`\"");
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, Zone);
+        parsed.OfType<ARecord>().Single().Addresses.ShouldContain("`value`");
+    }
+
+    [Fact]
+    public void Serialize_ARecord_ValueWithColon_IsQuotedAndRoundTrips()
+    {
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["key:value"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        yaml.ShouldContain("\"key:value\"");
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, Zone);
+        parsed.OfType<ARecord>().Single().Addresses.ShouldContain("key:value");
+    }
+
+    [Fact]
+    public void Serialize_ARecord_ValueWithHash_IsQuotedAndRoundTrips()
+    {
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["val#comment"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        yaml.ShouldContain("\"val#comment\"");
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, Zone);
+        parsed.OfType<ARecord>().Single().Addresses.ShouldContain("val#comment");
+    }
+
+    [Fact]
+    public void Serialize_ARecord_ValueWithDoubleQuote_IsEscapedAndRoundTrips()
+    {
+        const string val = "say \"hello\"";
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = [val]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        // Must be escaped inside the outer double-quotes
+        yaml.ShouldContain("\\\"");
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, Zone);
+        parsed.OfType<ARecord>().Single().Addresses.ShouldContain(val);
+    }
+
+    [Fact]
+    public void Serialize_ARecord_ValueWithBackslash_IsEscapedAndRoundTrips()
+    {
+        const string val = @"C:\path";
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = [val]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        yaml.ShouldContain("\\\\"); // backslash doubled
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, Zone);
+        parsed.OfType<ARecord>().Single().Addresses.ShouldContain(val);
+    }
+
+    [Fact]
+    public void Serialize_ARecord_EmptyValue_IsQuotedAsEmptyString()
+    {
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = [""]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        // QuoteScalar("") → ""
+        yaml.ShouldContain("\"\"");
+    }
+
+    [Theory]
+    [InlineData("yes")]
+    [InlineData("no")]
+    [InlineData("true")]
+    [InlineData("false")]
+    [InlineData("null")]
+    [InlineData("~")]
+    public void Serialize_ARecord_YamlKeyword_RoundTrips(string keyword)
+    {
+        // These are YAML reserved words — they'd be parsed as bool/null without quoting.
+        // QuoteScalar doesn't specifically quote them (they don't start with @ or ` and
+        // don't contain special chars). This test documents current behavior:
+        // YAML providers treat them as plain scalars which YamlDotNet may type-coerce.
+        // The serializer should emit them and the round-trip must preserve the string.
+        var zone = MakeZone(new ARecord
+        {
+            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = [keyword]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        // At minimum the YAML should contain the keyword text
+        yaml.ShouldContain(keyword);
+    }
+
+    // ── QuoteScalar — NS record nameservers ───────────────────────────────────
+
+    [Fact]
+    public void Serialize_NsRecord_MultipleNameservers_AllRoundTrip()
+    {
+        var zone = MakeZone(new NsRecord
+        {
+            Name         = "example.com.",
+            Type         = "NS",
+            Ttl          = 3600,
+            Nameservers  = ["ns1.porkbun.com.", "ns2.porkbun.com.", "ns3.porkbun.com."]
+        });
+
+        var parsed = RoundtripParsed(zone);
+        var ns = parsed.OfType<NsRecord>().Single();
+        ns.Nameservers.Count.ShouldBe(3);
+        ns.Nameservers.ShouldContain("ns1.porkbun.com.");
+    }
+
+    // ── QuoteTxt — TXT record values ──────────────────────────────────────────
+
+    [Fact]
+    public void Serialize_TxtRecord_ValueWithColon_IsQuotedAndRoundTrips()
+    {
+        var zone = MakeZone(new TxtRecord
+        {
+            Name = "example.com.", Type = "TXT", Ttl = 600, Values = ["k=v:extra"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        yaml.ShouldContain("\"k=v:extra\"");
+
+        var parsed = YamlProvider.ParseZoneYaml(yaml, Zone);
+        parsed.OfType<TxtRecord>().Single().Values.ShouldContain("k=v:extra");
+    }
+
+    [Fact]
+    public void Serialize_TxtRecord_ValueWithBackslash_IsEscapedAndRoundTrips()
+    {
+        const string val = @"path\to\file";
+        var zone = MakeZone(new TxtRecord
+        {
+            Name = "example.com.", Type = "TXT", Ttl = 600, Values = [val]
+        });
+
+        var parsed = RoundtripParsed(zone);
+        parsed.OfType<TxtRecord>().Single().Values.ShouldContain(val);
+    }
+
+    [Fact]
+    public void Serialize_TxtRecord_ValueWithDoubleQuote_IsEscapedAndRoundTrips()
+    {
+        const string val = "say \"hi\"";
+        var zone = MakeZone(new TxtRecord
+        {
+            Name = "example.com.", Type = "TXT", Ttl = 600, Values = [val]
+        });
+
+        var parsed = RoundtripParsed(zone);
+        parsed.OfType<TxtRecord>().Single().Values.ShouldContain(val);
+    }
+
+    [Fact]
+    public void Serialize_TxtRecord_EmptyValue_SerializedAsEmptyQuotes()
+    {
+        // Empty TXT values are serialized as "" in YAML. YamlProvider's GetStringList
+        // filters out empty strings on parse (Where(s => s.Length > 0)), so round-trip
+        // produces no records. This test documents the known behavior.
+        var zone = MakeZone(new TxtRecord
+        {
+            Name = "example.com.", Type = "TXT", Ttl = 600, Values = [""]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone);
+        // Serializer emits "" — confirming QuoteTxt("") produces quoted empty string
+        yaml.ShouldContain("value:");
+        // Round-trip: parser produces a TxtRecord but with an empty Values list
+        // because GetStringList filters out empty strings (Where(s => s.Length > 0))
+        var parsed = YamlProvider.ParseZoneYaml(yaml, Zone);
+        var txt = parsed.OfType<TxtRecord>().Single();
+        txt.Values.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Serialize_TxtRecord_OnlySpecialChars_RoundTrips()
+    {
+        const string val = ":::###\\\"\\\"";
+        var zone = MakeZone(new TxtRecord
+        {
+            Name = "example.com.", Type = "TXT", Ttl = 600, Values = [val]
+        });
+
+        var parsed = RoundtripParsed(zone);
+        parsed.OfType<TxtRecord>().Single().Values.ShouldContain(val);
+    }
+
+    [Fact]
+    public void Serialize_TxtRecord_LongDkimValue_RoundTrips()
+    {
+        // Real DKIM keys are 200+ chars
+        var val = "v=DKIM1; k=rsa; p=" + new string('A', 200);
+        var zone = MakeZone(new TxtRecord
+        {
+            Name = "mail._domainkey.example.com.", Type = "TXT", Ttl = 300, Values = [val]
+        });
+
+        var parsed = RoundtripParsed(zone);
+        parsed.OfType<TxtRecord>().Single().Values.ShouldContain(val);
+    }
+
+    // ── provider name in header ───────────────────────────────────────────────
+
+    [Fact]
+    public void Serialize_WithProviderName_HeaderContainsProviderName()
+    {
+        var zone = MakeZone(new ARecord
+        {
+            Name = "example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone, providerName: "cloudflare");
+
+        yaml.ShouldContain("from cloudflare");
+    }
+
+    [Fact]
+    public void Serialize_WithoutProviderName_HeaderOmitsFrom()
+    {
+        var zone = MakeZone(new ARecord
+        {
+            Name = "example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"]
+        });
+
+        var yaml = ZoneYamlSerializer.Serialize(zone, providerName: null);
+
+        yaml.ShouldNotContain("from null");
+        yaml.ShouldContain("Imported by dns-sync");
+    }
+}

--- a/tests/DnsSync.Tests/Providers/Yaml/ZoneYamlSerializerEdgeCaseTests.cs
+++ b/tests/DnsSync.Tests/Providers/Yaml/ZoneYamlSerializerEdgeCaseTests.cs
@@ -33,7 +33,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         // "@." is not a valid IP but providers may emit odd values; serializer must quote it.
         var zone = MakeZone(new ARecord
         {
-            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["@."]
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = ["@."]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -49,7 +52,10 @@ public class ZoneYamlSerializerEdgeCaseTests
     {
         var zone = MakeZone(new ARecord
         {
-            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["`value`"]
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = ["`value`"]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -64,7 +70,10 @@ public class ZoneYamlSerializerEdgeCaseTests
     {
         var zone = MakeZone(new ARecord
         {
-            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["key:value"]
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = ["key:value"]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -79,7 +88,10 @@ public class ZoneYamlSerializerEdgeCaseTests
     {
         var zone = MakeZone(new ARecord
         {
-            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = ["val#comment"]
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = ["val#comment"]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -95,7 +107,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         const string val = "say \"hello\"";
         var zone = MakeZone(new ARecord
         {
-            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = [val]
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = [val]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -112,7 +127,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         const string val = @"C:\path";
         var zone = MakeZone(new ARecord
         {
-            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = [val]
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = [val]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -127,7 +145,10 @@ public class ZoneYamlSerializerEdgeCaseTests
     {
         var zone = MakeZone(new ARecord
         {
-            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = [""]
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = [""]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -151,7 +172,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         // The serializer should emit them and the round-trip must preserve the string.
         var zone = MakeZone(new ARecord
         {
-            Name = "www.example.com.", Type = "A", Ttl = 300, Addresses = [keyword]
+            Name = "www.example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = [keyword]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -166,10 +190,10 @@ public class ZoneYamlSerializerEdgeCaseTests
     {
         var zone = MakeZone(new NsRecord
         {
-            Name         = "example.com.",
-            Type         = "NS",
-            Ttl          = 3600,
-            Nameservers  = ["ns1.porkbun.com.", "ns2.porkbun.com.", "ns3.porkbun.com."]
+            Name = "example.com.",
+            Type = "NS",
+            Ttl = 3600,
+            Nameservers = ["ns1.porkbun.com.", "ns2.porkbun.com.", "ns3.porkbun.com."]
         });
 
         var parsed = RoundtripParsed(zone);
@@ -185,7 +209,10 @@ public class ZoneYamlSerializerEdgeCaseTests
     {
         var zone = MakeZone(new TxtRecord
         {
-            Name = "example.com.", Type = "TXT", Ttl = 600, Values = ["k=v:extra"]
+            Name = "example.com.",
+            Type = "TXT",
+            Ttl = 600,
+            Values = ["k=v:extra"]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -201,7 +228,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         const string val = @"path\to\file";
         var zone = MakeZone(new TxtRecord
         {
-            Name = "example.com.", Type = "TXT", Ttl = 600, Values = [val]
+            Name = "example.com.",
+            Type = "TXT",
+            Ttl = 600,
+            Values = [val]
         });
 
         var parsed = RoundtripParsed(zone);
@@ -214,7 +244,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         const string val = "say \"hi\"";
         var zone = MakeZone(new TxtRecord
         {
-            Name = "example.com.", Type = "TXT", Ttl = 600, Values = [val]
+            Name = "example.com.",
+            Type = "TXT",
+            Ttl = 600,
+            Values = [val]
         });
 
         var parsed = RoundtripParsed(zone);
@@ -229,7 +262,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         // produces no records. This test documents the known behavior.
         var zone = MakeZone(new TxtRecord
         {
-            Name = "example.com.", Type = "TXT", Ttl = 600, Values = [""]
+            Name = "example.com.",
+            Type = "TXT",
+            Ttl = 600,
+            Values = [""]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone);
@@ -248,7 +284,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         const string val = ":::###\\\"\\\"";
         var zone = MakeZone(new TxtRecord
         {
-            Name = "example.com.", Type = "TXT", Ttl = 600, Values = [val]
+            Name = "example.com.",
+            Type = "TXT",
+            Ttl = 600,
+            Values = [val]
         });
 
         var parsed = RoundtripParsed(zone);
@@ -262,7 +301,10 @@ public class ZoneYamlSerializerEdgeCaseTests
         var val = "v=DKIM1; k=rsa; p=" + new string('A', 200);
         var zone = MakeZone(new TxtRecord
         {
-            Name = "mail._domainkey.example.com.", Type = "TXT", Ttl = 300, Values = [val]
+            Name = "mail._domainkey.example.com.",
+            Type = "TXT",
+            Ttl = 300,
+            Values = [val]
         });
 
         var parsed = RoundtripParsed(zone);
@@ -276,7 +318,10 @@ public class ZoneYamlSerializerEdgeCaseTests
     {
         var zone = MakeZone(new ARecord
         {
-            Name = "example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"]
+            Name = "example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = ["1.2.3.4"]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone, providerName: "cloudflare");
@@ -289,7 +334,10 @@ public class ZoneYamlSerializerEdgeCaseTests
     {
         var zone = MakeZone(new ARecord
         {
-            Name = "example.com.", Type = "A", Ttl = 300, Addresses = ["1.2.3.4"]
+            Name = "example.com.",
+            Type = "A",
+            Ttl = 300,
+            Addresses = ["1.2.3.4"]
         });
 
         var yaml = ZoneYamlSerializer.Serialize(zone, providerName: null);

--- a/tests/DnsSync.Tests/Validation/ZoneValidatorBoundaryTests.cs
+++ b/tests/DnsSync.Tests/Validation/ZoneValidatorBoundaryTests.cs
@@ -16,9 +16,9 @@ public class ZoneValidatorBoundaryTests
 
     private static ARecord ARecord(int ttl) => new()
     {
-        Name      = "www.example.com.",
-        Type      = "A",
-        Ttl       = ttl,
+        Name = "www.example.com.",
+        Type = "A",
+        Ttl = ttl,
         Addresses = ["1.2.3.4"]
     };
 
@@ -77,9 +77,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new SrvRecord
         {
-            Name   = "_sip._tcp.example.com.",
-            Type   = "SRV",
-            Ttl    = 600,
+            Name = "_sip._tcp.example.com.",
+            Type = "SRV",
+            Ttl = 600,
             Values = [new SrvValue(10, 20, 0, "sip.example.com.")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
@@ -90,9 +90,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new SrvRecord
         {
-            Name   = "_sip._tcp.example.com.",
-            Type   = "SRV",
-            Ttl    = 600,
+            Name = "_sip._tcp.example.com.",
+            Type = "SRV",
+            Ttl = 600,
             Values = [new SrvValue(10, 20, 65535, "sip.example.com.")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
@@ -103,9 +103,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new SrvRecord
         {
-            Name   = "_sip._tcp.example.com.",
-            Type   = "SRV",
-            Ttl    = 600,
+            Name = "_sip._tcp.example.com.",
+            Type = "SRV",
+            Ttl = 600,
             Values = [new SrvValue(10, 20, 65536, "sip.example.com.")]
         });
         var result = ZoneValidator.Validate(zone);
@@ -118,9 +118,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new SrvRecord
         {
-            Name   = "_sip._tcp.example.com.",
-            Type   = "SRV",
-            Ttl    = 600,
+            Name = "_sip._tcp.example.com.",
+            Type = "SRV",
+            Ttl = 600,
             Values = [new SrvValue(10, 20, -1, "sip.example.com.")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeFalse();
@@ -131,9 +131,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new SrvRecord
         {
-            Name   = "_sip._tcp.example.com.",
-            Type   = "SRV",
-            Ttl    = 600,
+            Name = "_sip._tcp.example.com.",
+            Type = "SRV",
+            Ttl = 600,
             Values = [new SrvValue(0, 0, 5060, "sip.example.com.")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
@@ -146,9 +146,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new MxRecord
         {
-            Name   = "example.com.",
-            Type   = "MX",
-            Ttl    = 3600,
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 3600,
             Values = [new MxValue(0, "mail.example.com.")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
@@ -159,9 +159,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new MxRecord
         {
-            Name   = "example.com.",
-            Type   = "MX",
-            Ttl    = 3600,
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 3600,
             Values = [new MxValue(65535, "mail.example.com.")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
@@ -172,9 +172,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new MxRecord
         {
-            Name   = "example.com.",
-            Type   = "MX",
-            Ttl    = 3600,
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 3600,
             Values = [new MxValue(-1, "mail.example.com.")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeFalse();
@@ -185,9 +185,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new MxRecord
         {
-            Name   = "example.com.",
-            Type   = "MX",
-            Ttl    = 3600,
+            Name = "example.com.",
+            Type = "MX",
+            Ttl = 3600,
             Values = [new MxValue(65536, "mail.example.com.")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeFalse();
@@ -200,9 +200,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new CaaRecord
         {
-            Name   = "example.com.",
-            Type   = "CAA",
-            Ttl    = 3600,
+            Name = "example.com.",
+            Type = "CAA",
+            Ttl = 3600,
             Values = [new CaaValue(0, "issue", "letsencrypt.org")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
@@ -213,9 +213,9 @@ public class ZoneValidatorBoundaryTests
     {
         var zone = ZoneWith(new CaaRecord
         {
-            Name   = "example.com.",
-            Type   = "CAA",
-            Ttl    = 3600,
+            Name = "example.com.",
+            Type = "CAA",
+            Ttl = 3600,
             Values = [new CaaValue(128, "issue", "letsencrypt.org")]
         });
         ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();

--- a/tests/DnsSync.Tests/Validation/ZoneValidatorBoundaryTests.cs
+++ b/tests/DnsSync.Tests/Validation/ZoneValidatorBoundaryTests.cs
@@ -1,0 +1,223 @@
+using DnsSync.Core;
+using DnsSync.Core.Records;
+using DnsSync.Validation;
+using Shouldly;
+
+namespace DnsSync.Tests.Validation;
+
+/// <summary>
+/// Boundary and edge-case tests for ZoneValidator:
+/// TTL limits, SRV/MX/CAA field boundaries, empty zone.
+/// </summary>
+public class ZoneValidatorBoundaryTests
+{
+    private static DnsZone ZoneWith(params DnsRecord[] records) =>
+        new() { Name = "example.com.", Records = records };
+
+    private static ARecord ARecord(int ttl) => new()
+    {
+        Name      = "www.example.com.",
+        Type      = "A",
+        Ttl       = ttl,
+        Addresses = ["1.2.3.4"]
+    };
+
+    // ── empty zone ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_ZoneWithNoRecords_IsValid()
+    {
+        var result = ZoneValidator.Validate(new DnsZone { Name = "example.com.", Records = [] });
+        result.IsValid.ShouldBeTrue();
+        result.Errors.ShouldBeEmpty();
+    }
+
+    // ── TTL boundaries ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_TtlZero_IsValid()
+    {
+        var result = ZoneValidator.Validate(ZoneWith(ARecord(0)));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_TtlOne_ReturnsWarning()
+    {
+        var result = ZoneValidator.Validate(ZoneWith(ARecord(1)));
+        result.Warnings.ShouldContain(w => w.Contains("TTL") || w.Contains("low") || w.Contains("1"));
+    }
+
+    [Fact]
+    public void Validate_TtlAt59_ReturnsWarning()
+    {
+        var result = ZoneValidator.Validate(ZoneWith(ARecord(59)));
+        result.Warnings.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_TtlAt300_NoWarning()
+    {
+        var result = ZoneValidator.Validate(ZoneWith(ARecord(300)));
+        result.Warnings.ShouldBeEmpty();
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_TtlAtMaxInt32_IsValid()
+    {
+        var result = ZoneValidator.Validate(ZoneWith(ARecord(int.MaxValue)));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    // ── SRV port boundaries ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_SrvPortZero_IsValid()
+    {
+        var zone = ZoneWith(new SrvRecord
+        {
+            Name   = "_sip._tcp.example.com.",
+            Type   = "SRV",
+            Ttl    = 600,
+            Values = [new SrvValue(10, 20, 0, "sip.example.com.")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_SrvPortMax_IsValid()
+    {
+        var zone = ZoneWith(new SrvRecord
+        {
+            Name   = "_sip._tcp.example.com.",
+            Type   = "SRV",
+            Ttl    = 600,
+            Values = [new SrvValue(10, 20, 65535, "sip.example.com.")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_SrvPortExceedsMax_ReturnsError()
+    {
+        var zone = ZoneWith(new SrvRecord
+        {
+            Name   = "_sip._tcp.example.com.",
+            Type   = "SRV",
+            Ttl    = 600,
+            Values = [new SrvValue(10, 20, 65536, "sip.example.com.")]
+        });
+        var result = ZoneValidator.Validate(zone);
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.Contains("port") || e.Contains("65536"));
+    }
+
+    [Fact]
+    public void Validate_SrvNegativePort_ReturnsError()
+    {
+        var zone = ZoneWith(new SrvRecord
+        {
+            Name   = "_sip._tcp.example.com.",
+            Type   = "SRV",
+            Ttl    = 600,
+            Values = [new SrvValue(10, 20, -1, "sip.example.com.")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Validate_SrvPriorityZero_IsValid()
+    {
+        var zone = ZoneWith(new SrvRecord
+        {
+            Name   = "_sip._tcp.example.com.",
+            Type   = "SRV",
+            Ttl    = 600,
+            Values = [new SrvValue(0, 0, 5060, "sip.example.com.")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
+    }
+
+    // ── MX preference boundaries ──────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_MxPreferenceZero_IsValid()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name   = "example.com.",
+            Type   = "MX",
+            Ttl    = 3600,
+            Values = [new MxValue(0, "mail.example.com.")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_MxPreference65535_IsValid()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name   = "example.com.",
+            Type   = "MX",
+            Ttl    = 3600,
+            Values = [new MxValue(65535, "mail.example.com.")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_MxPreferenceNegative_ReturnsError()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name   = "example.com.",
+            Type   = "MX",
+            Ttl    = 3600,
+            Values = [new MxValue(-1, "mail.example.com.")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Validate_MxPreferenceExceedsMax_ReturnsError()
+    {
+        var zone = ZoneWith(new MxRecord
+        {
+            Name   = "example.com.",
+            Type   = "MX",
+            Ttl    = 3600,
+            Values = [new MxValue(65536, "mail.example.com.")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeFalse();
+    }
+
+    // ── CAA flags boundary ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_CaaFlagsZero_IsValid()
+    {
+        var zone = ZoneWith(new CaaRecord
+        {
+            Name   = "example.com.",
+            Type   = "CAA",
+            Ttl    = 3600,
+            Values = [new CaaValue(0, "issue", "letsencrypt.org")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_CaaFlagsMax_IsValid()
+    {
+        var zone = ZoneWith(new CaaRecord
+        {
+            Name   = "example.com.",
+            Type   = "CAA",
+            Ttl    = 3600,
+            Values = [new CaaValue(128, "issue", "letsencrypt.org")]
+        });
+        ZoneValidator.Validate(zone).IsValid.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Fixes #60

## Summary

- Adds `zone_groups:` config section for auto-discovery of zones from a provider without listing each one explicitly
- Introduces `IZoneResolver` service that merges explicit `zones:` + discovered `zone_groups:` — decoupling zone loading from command logic
- Explicit `zones:` always wins over `zone_groups:` (warning shown on conflict)
- Optional `include_pattern` / `exclude_pattern` regex filters per group
- All 4 commands (`plan`, `apply`, `drift`, `validate`) now use `IZoneResolver`
- Config validation updated for `zone_groups`
- Config summary now shows zone group count when > 0

## New config structure

```yaml
zone_groups:
  all-prd:
    source: yaml_prd
    targets:
      - cf_prd
    include_pattern: ".*\\.com\\."   # optional
    exclude_pattern: "staging\\..*"  # optional
```

## Test plan

- [ ] Config with only `zones:` → behavior identical to current (no regression)
- [ ] Config with `zone_groups:` → discovered zones are planned/applied/drifted
- [ ] Zone in both `zones:` and `zone_groups:` → explicit wins, warning shown
- [ ] `include_pattern` / `exclude_pattern` filter correctly
- [ ] `dns-sync validate` validates zone_groups zones
- [ ] `dns-sync drift` checks zone_groups zones
- [ ] `dotnet test` → all 188 tests pass